### PR TITLE
Feature: Project Page Redesign

### DIFF
--- a/additional-env.d.ts
+++ b/additional-env.d.ts
@@ -9,6 +9,7 @@ declare global {
       HACKNEY_JWT_SECRET: string;
       AUTHORISED_USER_GROUP: string;
       AUTHORISED_ADMIN_GROUP: string;
+      ENDPOINT_API: string;
     }
   }
 }

--- a/api/projectLinks.ts
+++ b/api/projectLinks.ts
@@ -1,0 +1,50 @@
+import axios from "axios";
+import { ProjectLink } from "../types";
+
+export const getLinksByProject = async (projectId: number): Promise<ProjectLink[] | []> => {
+    // const { data } = await axios.get(`/projects/${projectId}/links`, {
+    //     headers,
+    // })
+
+    // return data
+
+    return new Promise((resolve) => {
+        setTimeout(
+            () =>
+                resolve([{
+                    id: 1,
+                    project_id: 2,
+                    type: "GitHub",
+                    link: "https://github.com/",
+                }]),
+            3000
+        );
+    })
+
+}
+
+export const addProjectLink = async (project_id: number, formData: Record<string, string | number>): Promise<any> => {
+    // const { data } = await axios.post(`/projects/${project_id}/team`, formData, {
+    //     headers,
+    // })
+
+    // return data
+
+    return new Promise((resolve) => {
+        setTimeout(
+            () => resolve(console.log(`Form data is ${JSON.stringify(formData)}`)),
+            1000
+        );
+    });
+}
+
+export const removeProjectLink = async (
+    link_id: number
+): Promise<void> => {
+    // await axios.delete(
+    //   `${ENDPOINT_API}/links/${link_id}`,
+    //   {
+    //     headers,
+    //   }
+    // );
+};

--- a/api/projectLinks.ts
+++ b/api/projectLinks.ts
@@ -1,50 +1,54 @@
 import axios from "axios";
 import { ProjectLink } from "../types";
 
-export const getLinksByProject = async (projectId: number): Promise<ProjectLink[] | []> => {
-    // const { data } = await axios.get(`/projects/${projectId}/links`, {
-    //     headers,
-    // })
+export const getLinksByProject = async (
+  projectId: number
+): Promise<ProjectLink[] | []> => {
+  // const { data } = await axios.get(`/projects/${projectId}/links`, {
+  //     headers,
+  // })
 
-    // return data
+  // return data
 
-    return new Promise((resolve) => {
-        setTimeout(
-            () =>
-                resolve([{
-                    id: 1,
-                    project_id: 2,
-                    type: "GitHub",
-                    link: "https://github.com/",
-                }]),
-            3000
-        );
-    })
+  return new Promise((resolve) => {
+    setTimeout(
+      () =>
+        resolve([
+          {
+            id: 1,
+            project_id: 2,
+            type: "GitHub",
+            link: "https://github.com/",
+          },
+        ]),
+      3000
+    );
+  });
+};
 
-}
+export const addProjectLink = async (
+  project_id: number,
+  formData: Record<string, string | number>
+): Promise<any> => {
+  // const { data } = await axios.post(`/projects/${project_id}/team`, formData, {
+  //     headers,
+  // })
 
-export const addProjectLink = async (project_id: number, formData: Record<string, string | number>): Promise<any> => {
-    // const { data } = await axios.post(`/projects/${project_id}/team`, formData, {
-    //     headers,
-    // })
+  // return data
 
-    // return data
+  return new Promise((resolve) => {
+    setTimeout(
+      () => resolve(console.log(`Form data is ${JSON.stringify(formData)}`)),
+      1000
+    );
+  });
+};
 
-    return new Promise((resolve) => {
-        setTimeout(
-            () => resolve(console.log(`Form data is ${JSON.stringify(formData)}`)),
-            1000
-        );
-    });
-}
-
-export const removeProjectLink = async (
-    link_id: number
-): Promise<void> => {
-    // await axios.delete(
-    //   `${ENDPOINT_API}/links/${link_id}`,
-    //   {
-    //     headers,
-    //   }
-    // );
+export const removeProjectLink = async (link_id: number): Promise<void> => {
+  // await axios.delete(
+  //   `${ENDPOINT_API}/links/${link_id}`,
+  //   {
+  //     headers,
+  //   }
+  // );
 };

--- a/api/projectTeam.ts
+++ b/api/projectTeam.ts
@@ -1,51 +1,57 @@
 import axios from "axios";
 import { ProjectMember } from "../types";
 
-export const getTeamByProject = async (projectId: number): Promise<ProjectMember[] | []> => {
-    // const { data } = await axios.get(`/projects/${projectId}/team`, {
-    //     headers,
-    // })
+export const getTeamByProject = async (
+  projectId: number
+): Promise<ProjectMember[] | []> => {
+  // const { data } = await axios.get(`/projects/${projectId}/team`, {
+  //     headers,
+  // })
 
-    // return data
+  // return data
 
-    return new Promise((resolve) => {
-        setTimeout(
-            () =>
-                resolve([{
-                    id: 1,
-                    member_id: 2,
-                    project_id: 1,
-                    project_member: "Joe Rogan",
-                    role: "Developer",
-                }]),
-            3000
-        );
-    })
+  return new Promise((resolve) => {
+    setTimeout(
+      () =>
+        resolve([
+          {
+            id: 1,
+            member_id: 2,
+            project_id: 1,
+            project_member: "Joe Rogan",
+            role: "Developer",
+          },
+        ]),
+      3000
+    );
+  });
+};
 
-}
+export const addTeamMember = async (
+  project_id: number,
+  formData: Record<string, string | number>
+): Promise<any> => {
+  // const { data } = await axios.post(`/projects/${project_id}/team`, formData, {
+  //     headers,
+  // })
 
-export const addTeamMember = async (project_id: number, formData: Record<string, string | number>): Promise<any> => {
-    // const { data } = await axios.post(`/projects/${project_id}/team`, formData, {
-    //     headers,
-    // })
+  // return data
 
-    // return data
-
-    return new Promise((resolve) => {
-        setTimeout(
-            () => resolve(console.log(`Form data is ${JSON.stringify(formData)}`)),
-            1000
-        );
-    });
-}
+  return new Promise((resolve) => {
+    setTimeout(
+      () => resolve(console.log(`Form data is ${JSON.stringify(formData)}`)),
+      1000
+    );
+  });
+};
 
 export const removeTeamMember = async (
-    team_member_id: number
+  team_member_id: number
 ): Promise<void> => {
-    // await axios.delete(
-    //   `${ENDPOINT_API}/team/${team_member_id}`,
-    //   {
-    //     headers,
-    //   }
-    // );
+  // await axios.delete(
+  //   `${ENDPOINT_API}/team/${team_member_id}`,
+  //   {
+  //     headers,
+  //   }
+  // );
 };

--- a/api/projectTeam.ts
+++ b/api/projectTeam.ts
@@ -1,0 +1,51 @@
+import axios from "axios";
+import { ProjectMember } from "../types";
+
+export const getTeamByProject = async (projectId: number): Promise<ProjectMember[] | []> => {
+    // const { data } = await axios.get(`/projects/${projectId}/team`, {
+    //     headers,
+    // })
+
+    // return data
+
+    return new Promise((resolve) => {
+        setTimeout(
+            () =>
+                resolve([{
+                    id: 1,
+                    member_id: 2,
+                    project_id: 1,
+                    project_member: "Joe Rogan",
+                    role: "Developer",
+                }]),
+            3000
+        );
+    })
+
+}
+
+export const addTeamMember = async (project_id: number, formData: Record<string, string | number>): Promise<any> => {
+    // const { data } = await axios.post(`/projects/${project_id}/team`, formData, {
+    //     headers,
+    // })
+
+    // return data
+
+    return new Promise((resolve) => {
+        setTimeout(
+            () => resolve(console.log(`Form data is ${JSON.stringify(formData)}`)),
+            1000
+        );
+    });
+}
+
+export const removeTeamMember = async (
+    team_member_id: number
+): Promise<void> => {
+    // await axios.delete(
+    //   `${ENDPOINT_API}/team/${team_member_id}`,
+    //   {
+    //     headers,
+    //   }
+    // );
+};

--- a/api/projects.ts
+++ b/api/projects.ts
@@ -12,14 +12,6 @@ export const getProject = async (projectId: number): Promise<Project> => {
           size: "Large",
           stage: "Discovery",
           type: "Tech",
-          project_links: [
-            { name: "Google Drive", link: "fake link" },
-            { name: "Github", link: "second fake link" },
-          ],
-          project_team: [
-            { name: "someone", role: "Dev" },
-            { name: "again someone", role: "Manager" },
-          ],
         }),
       3000
     );

--- a/components/Autocomplete/Autocomplete.tsx
+++ b/components/Autocomplete/Autocomplete.tsx
@@ -12,7 +12,7 @@ interface Props {
   required?: boolean;
   rules?: RegisterOptions;
   onChange: any;
-  value: string;
+  value: string | number;
   choices: {
     value: number | string;
     text: string;

--- a/components/Modal/Modal.spec.tsx
+++ b/components/Modal/Modal.spec.tsx
@@ -1,0 +1,24 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import Modal from "./Modal";
+
+describe('Modal component', () => {
+    it('renders correctly when opened', () => {
+        render(
+            <Modal isOpen={true} onDismiss={jest.fn()} title="Some Title">
+                Test
+            </Modal>);
+        expect(screen.getByText("Some Title"));
+        expect(screen.getByText("Test"));
+    })
+
+    it('calls the correct callback when the modal is closed', () => {
+        const closeFunction = jest.fn()
+        render(
+            <Modal isOpen={true} onDismiss={closeFunction} title="Some Title">
+                Test
+            </Modal>);
+
+        fireEvent.click(screen.getByText("Close"));
+        expect(closeFunction).toBeCalled();
+    })
+})

--- a/components/Modal/Modal.tsx
+++ b/components/Modal/Modal.tsx
@@ -1,47 +1,48 @@
-import React from 'react';
-import { Dialog } from '@reach/dialog';
+import React from "react";
+import { Dialog } from "@reach/dialog";
 
 interface Props {
-    isOpen: boolean;
-    onDismiss: () => void;
-    children: React.ReactChild | React.ReactChild[];
-    title: string;
+  isOpen: boolean;
+  onDismiss: () => void;
+  children: React.ReactChild | React.ReactChild[];
+  title: string;
 }
 
 const Modal = ({
-    isOpen,
-    onDismiss,
-    children,
-    title,
-    ...props }: Props): React.ReactElement => {
-    return (
-        <Dialog
-            isOpen={isOpen}
-            onDismiss={onDismiss}
-            aria-label={title}
-            className="lbh-dialog"
-            {...props}
-        >
-            <h2 className="lbh-heading-h2 lbh-dialog__title govuk-!-margin-bottom-6">
-                {title}
-            </h2>
-            {children}
-            <button onClick={onDismiss} className="lbh-dialog__close">
-                <span className="govuk-visually-hidden">Close</span>
+  isOpen,
+  onDismiss,
+  children,
+  title,
+  ...props
+}: Props): React.ReactElement => {
+  return (
+    <Dialog
+      isOpen={isOpen}
+      onDismiss={onDismiss}
+      aria-label={title}
+      className="lbh-dialog"
+      {...props}
+    >
+      <h2 className="lbh-heading-h2 lbh-dialog__title govuk-!-margin-bottom-6">
+        {title}
+      </h2>
+      {children}
+      <button onClick={onDismiss} className="lbh-dialog__close">
+        <span className="govuk-visually-hidden">Close</span>
 
-                <svg width="18" height="18" viewBox="0 0 13 13" fill="none">
-                    <path
-                        d="M-0.0501709 1.36379L1.36404 -0.050415L12.6778 11.2633L11.2635 12.6775L-0.0501709 1.36379Z"
-                        fill="#0B0C0C"
-                    />
-                    <path
-                        d="M11.2635 -0.050293L12.6778 1.36392L1.36404 12.6776L-0.0501709 11.2634L11.2635 -0.050293Z"
-                        fill="#0B0C0C"
-                    />
-                </svg>
-            </button>
-        </Dialog>
-    )
-}
+        <svg width="18" height="18" viewBox="0 0 13 13" fill="none">
+          <path
+            d="M-0.0501709 1.36379L1.36404 -0.050415L12.6778 11.2633L11.2635 12.6775L-0.0501709 1.36379Z"
+            fill="#0B0C0C"
+          />
+          <path
+            d="M11.2635 -0.050293L12.6778 1.36392L1.36404 12.6776L-0.0501709 11.2634L11.2635 -0.050293Z"
+            fill="#0B0C0C"
+          />
+        </svg>
+      </button>
+    </Dialog>
+  );
+};
 
 export default Modal;

--- a/components/Modal/Modal.tsx
+++ b/components/Modal/Modal.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { Dialog } from '@reach/dialog';
+
+interface Props {
+    isOpen: boolean;
+    onDismiss: () => void;
+    children: React.ReactChild | React.ReactChild[];
+    title: string;
+}
+
+const Modal = ({
+    isOpen,
+    onDismiss,
+    children,
+    title,
+    ...props }: Props): React.ReactElement => {
+    return (
+        <Dialog
+            isOpen={isOpen}
+            onDismiss={onDismiss}
+            aria-label={title}
+            className="lbh-dialog"
+            {...props}
+        >
+            <h2 className="lbh-heading-h2 lbh-dialog__title govuk-!-margin-bottom-6">
+                {title}
+            </h2>
+            {children}
+            <button onClick={onDismiss} className="lbh-dialog__close">
+                <span className="govuk-visually-hidden">Close</span>
+
+                <svg width="18" height="18" viewBox="0 0 13 13" fill="none">
+                    <path
+                        d="M-0.0501709 1.36379L1.36404 -0.050415L12.6778 11.2633L11.2635 12.6775L-0.0501709 1.36379Z"
+                        fill="#0B0C0C"
+                    />
+                    <path
+                        d="M11.2635 -0.050293L12.6778 1.36392L1.36404 12.6776L-0.0501709 11.2634L11.2635 -0.050293Z"
+                        fill="#0B0C0C"
+                    />
+                </svg>
+            </button>
+        </Dialog>
+    )
+}
+
+export default Modal;

--- a/components/ProjectView/ProjectDetails.tsx
+++ b/components/ProjectView/ProjectDetails.tsx
@@ -9,11 +9,13 @@ const ProjectDetails = ({ project }: Props): React.ReactElement => {
       <dl className="govuk-summary-list lbh-summary-list">
         <div className="govuk-summary-list__row">
           <dt className="govuk-summary-list__key">Project Contact</dt>
-          <dd className="govuk-summary-list__value">Test Value</dd>
+          <dd className="govuk-summary-list__value">
+            {project?.projectContact}
+          </dd>
         </div>
         <div className="govuk-summary-list__row">
-          <dt className="govuk-summary-list__key">Stage</dt>
-          <dd className="govuk-summary-list__value">{project?.stage}</dd>
+          <dt className="govuk-summary-list__key">Phase</dt>
+          <dd className="govuk-summary-list__value">{project?.phase}</dd>
         </div>
         <div className="govuk-summary-list__row">
           <dt className="govuk-summary-list__key">Size</dt>
@@ -21,16 +23,28 @@ const ProjectDetails = ({ project }: Props): React.ReactElement => {
         </div>
         <div className="govuk-summary-list__row">
           <dt className="govuk-summary-list__key">Type</dt>
-          <dd className="govuk-summary-list__value">{project?.type}</dd>
+          <dd className="govuk-summary-list__value">
+            {project?.category ? project.category : "N/A"}
+          </dd>
         </div>
-        {project?.project_dependencies && (
-          <div className="govuk-summary-list__row">
-            <dt className="govuk-summary-list__key">Project Dependencies</dt>
-            <dd className="govuk-summary-list__value">
-              {project?.project_dependencies}
-            </dd>
-          </div>
-        )}
+        <div className="govuk-summary-list__row">
+          <dt className="govuk-summary-list__key">Priority</dt>
+          <dd className="govuk-summary-list__value">
+            {project?.priority ? project.priority : "N/A"}
+          </dd>
+        </div>
+        <div className="govuk-summary-list__row">
+          <dt className="govuk-summary-list__key">Product Users</dt>
+          <dd className="govuk-summary-list__value">
+            {project?.productUsers ? project.productUsers : "N/A"}
+          </dd>
+        </div>
+        <div className="govuk-summary-list__row">
+          <dt className="govuk-summary-list__key">Project Dependencies</dt>
+          <dd className="govuk-summary-list__value">
+            {project?.dependencies ? project?.dependencies : "N/A"}
+          </dd>
+        </div>
       </dl>
     </div>
   );

--- a/components/ProjectView/ProjectLinks.spec.tsx
+++ b/components/ProjectView/ProjectLinks.spec.tsx
@@ -4,10 +4,10 @@ import { mockedProject } from "../../factories/projects";
 import ProjectLinks from "./ProjectLinks";
 
 describe("ProjectLinks component", () => {
-  const props = mockedProject.project_links;
+  const props = mockedProject;
 
   it("should render a ProjectLinks component with the correct data", () => {
-    const { asFragment } = render(<ProjectLinks content={props!} />);
+    const { asFragment } = render(<ProjectLinks project={props} />);
 
     expect(asFragment()).toMatchSnapshot();
   });

--- a/components/ProjectView/ProjectLinks.tsx
+++ b/components/ProjectView/ProjectLinks.tsx
@@ -1,12 +1,12 @@
 import { useState } from "react";
-import Link from 'next/link';
+import Link from "next/link";
 import { Project, ProjectLink } from "../../types";
 import style from "./ProjectView.module.scss";
 import ErrorMessage from "../ErrorMessage/ErrorMessage";
-import RemovalModal from "./RemovalModal"
+import RemovalModal from "./RemovalModal";
 import Router from "next/router";
 import { removeProjectLink, useProjectLinks } from "../../utils/projectLinks";
-
+import Spinner from "../Spinner/Spinner";
 
 interface ProjectLinksProps {
   project: Project;
@@ -16,7 +16,7 @@ const ProjectLinks = ({ project }: ProjectLinksProps): React.ReactElement => {
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
   const [linkToRemove, setLinkToRemove] = useState<ProjectLink>();
 
-  const { data: links, error } = useProjectLinks(project.project_id);
+  const { data: links, error } = useProjectLinks(project.id);
 
   if (error) {
     return (
@@ -24,19 +24,28 @@ const ProjectLinks = ({ project }: ProjectLinksProps): React.ReactElement => {
     );
   }
 
+  if (!links) {
+    return <Spinner />;
+  }
+
   return (
     <>
-      <RemovalModal removalItem={linkToRemove!} isOpen={isModalOpen} onDismiss={() => setIsModalOpen(false)} onFormSubmit={async () => {
-        setIsModalOpen(false);
-        if (linkToRemove) {
-          await removeProjectLink(project.project_id, linkToRemove.id)
-          Router.reload();
-        }
-      }} />
+      <RemovalModal
+        removalItem={linkToRemove!}
+        isOpen={isModalOpen}
+        onDismiss={() => setIsModalOpen(false)}
+        onFormSubmit={async () => {
+          setIsModalOpen(false);
+          if (linkToRemove) {
+            await removeProjectLink(project.id, linkToRemove.id);
+            Router.reload();
+          }
+        }}
+      />
       <section className="govuk-!-margin-bottom-8">
         <div className={style.heading}>
           <h2>Project Links</h2>
-          <Link href={`/projects/${project.project_id}/links/add`}>
+          <Link href={`/projects/${project.id}/links/add`}>
             <a className="lbh-link lbh-link--no-visited-state">
               Add a new link
             </a>
@@ -61,10 +70,18 @@ const ProjectLinks = ({ project }: ProjectLinksProps): React.ReactElement => {
             <tbody className="govuk-table__body">
               {links.map((link, contentIndex) => (
                 <tr className="govuk-table__row lbh-list" key={link.type}>
-                  <th scope="row" className="govuk-table__header">{link.type}</th>
+                  <th scope="row" className="govuk-table__header">
+                    {link.type}
+                  </th>
                   <td className="govuk-table__cell">{link.link}</td>
                   <td className="govuk-table__cell">
-                    <a className="lbh-link lbh-link--no-visited-state" href="#" onClick={() => { setIsModalOpen(true), setLinkToRemove(link) }}>
+                    <a
+                      className="lbh-link lbh-link--no-visited-state"
+                      href="#"
+                      onClick={() => {
+                        setIsModalOpen(true), setLinkToRemove(link);
+                      }}
+                    >
                       Remove{" "}
                     </a>
                   </td>
@@ -72,7 +89,9 @@ const ProjectLinks = ({ project }: ProjectLinksProps): React.ReactElement => {
               ))}
             </tbody>
           </table>
-        ) : (<p className="lbh-body">No team has been assigned for this project</p>)}
+        ) : (
+          <p className="lbh-body">No team has been assigned for this project</p>
+        )}
       </section>
     </>
   );

--- a/components/ProjectView/ProjectLinks.tsx
+++ b/components/ProjectView/ProjectLinks.tsx
@@ -1,22 +1,80 @@
+import { useState } from "react";
+import Link from 'next/link';
+import { Project, ProjectLink } from "../../types";
+import style from "./ProjectView.module.scss";
+import ErrorMessage from "../ErrorMessage/ErrorMessage";
+import RemovalModal from "./RemovalModal"
+import Router from "next/router";
+import { removeProjectLink, useProjectLinks } from "../../utils/projectLinks";
+
+
 interface ProjectLinksProps {
-  content: {
-    name: string;
-    link: string;
-  }[];
+  project: Project;
 }
 
-const ProjectLinks = ({ content }: ProjectLinksProps): React.ReactElement => {
+const ProjectLinks = ({ project }: ProjectLinksProps): React.ReactElement => {
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+  const [linkToRemove, setLinkToRemove] = useState<ProjectLink>();
+
+  const { data: links, error } = useProjectLinks(project.project_id);
+
+  if (error) {
+    return (
+      <ErrorMessage label="There was a problem with getting the project's links." />
+    );
+  }
+
   return (
-    <div>
-      <dl className="govuk-summary-list lbh-summary-list">
-        {content.map((content) => (
-          <div key={content.name} className="govuk-summary-list__row">
-            <dt className="govuk-summary-list__key">{content.name}</dt>
-            <dd className="govuk-summary-list__value">{content.link}</dd>
-          </div>
-        ))}
-      </dl>
-    </div>
+    <>
+      <RemovalModal removalItem={linkToRemove!} isOpen={isModalOpen} onDismiss={() => setIsModalOpen(false)} onFormSubmit={async () => {
+        setIsModalOpen(false);
+        if (linkToRemove) {
+          await removeProjectLink(project.project_id, linkToRemove.id)
+          Router.reload();
+        }
+      }} />
+      <section className="govuk-!-margin-bottom-8">
+        <div className={style.heading}>
+          <h2>Project Links</h2>
+          <Link href={`/projects/${project.project_id}/links/add`}>
+            <a className="lbh-link lbh-link--no-visited-state">
+              Add a new link
+            </a>
+          </Link>
+        </div>
+
+        {links && links.length > 0 ? (
+          <table className="govuk-table lbh-table">
+            <thead className="govuk-table__head">
+              <tr className="govuk-table__row">
+                <th scope="col" className="govuk-table__header">
+                  Type
+                </th>
+                <th scope="col" className="govuk-table__header">
+                  Link
+                </th>
+                <th scope="col" className="govuk-table__header">
+                  Action
+                </th>
+              </tr>
+            </thead>
+            <tbody className="govuk-table__body">
+              {links.map((link, contentIndex) => (
+                <tr className="govuk-table__row lbh-list" key={link.type}>
+                  <th scope="row" className="govuk-table__header">{link.type}</th>
+                  <td className="govuk-table__cell">{link.link}</td>
+                  <td className="govuk-table__cell">
+                    <a className="lbh-link lbh-link--no-visited-state" href="#" onClick={() => { setIsModalOpen(true), setLinkToRemove(link) }}>
+                      Remove{" "}
+                    </a>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        ) : (<p className="lbh-body">No team has been assigned for this project</p>)}
+      </section>
+    </>
   );
 };
 

--- a/components/ProjectView/ProjectTeam.spec.tsx
+++ b/components/ProjectView/ProjectTeam.spec.tsx
@@ -4,10 +4,10 @@ import { mockedProject } from "../../factories/projects";
 import ProjectTeam from "./ProjectTeam";
 
 describe("ProjectTeam component", () => {
-  const props = mockedProject.project_team;
+  const props = mockedProject;
 
   it("should render a ProjectTeam component with the correct data", () => {
-    const { asFragment } = render(<ProjectTeam content={props!} />);
+    const { asFragment } = render(<ProjectTeam project={props} />);
 
     expect(asFragment()).toMatchSnapshot();
   });

--- a/components/ProjectView/ProjectTeam.tsx
+++ b/components/ProjectView/ProjectTeam.tsx
@@ -1,23 +1,82 @@
+import Router from "next/router";
+import { useState } from "react";
+import Link from 'next/link';
+import { Project, ProjectMember } from "../../types";
+import style from "./ProjectView.module.scss";
+import RemovalModal from "./RemovalModal"
+import { removeTeamMember, useTeamMembers } from "../../utils/projectTeam";
+import ErrorMessage from "../ErrorMessage/ErrorMessage";
+
 interface ProjectTeamProps {
-  content: {
-    name: string;
-    role: string;
-  }[];
+  project: Project
 }
 
-const ProjectTeam = ({ content }: ProjectTeamProps): React.ReactElement => {
+const ProjectTeam = ({ project }: ProjectTeamProps): React.ReactElement => {
+  const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
+  const [memberToRemove, setMemberToRemove] = useState<ProjectMember>();
+
+  const { data: teamMembers, error } = useTeamMembers(project.project_id);
+
+  if (error) {
+    return (
+      <ErrorMessage label="There was a problem with getting the project's team members." />
+    );
+  }
+
   return (
-    <div>
-      <dl className="govuk-summary-list lbh-summary-list">
-        {content.map((content) => (
-          <div key={content.name} className="govuk-summary-list__row">
-            <dt className="govuk-summary-list__key">{content.name}</dt>
-            <dd className="govuk-summary-list__value">{content.role}</dd>
-          </div>
-        ))}
-      </dl>
-    </div>
-  );
+    <>
+      <RemovalModal removalItem={memberToRemove!} isOpen={isModalOpen} onDismiss={() => setIsModalOpen(false)} onFormSubmit={async () => {
+        setIsModalOpen(false);
+        if (memberToRemove) {
+          await removeTeamMember(project.project_id, memberToRemove.id)
+          Router.reload();
+        }
+      }} />
+
+      <section className="govuk-!-margin-bottom-8">
+        <div className={style.heading}>
+          <h2>Project Team</h2>
+          <Link href={`/projects/${project.project_id}/team/add`}>
+            <a className="lbh-link lbh-link--no-visited-state">
+              Add a new team member
+            </a>
+          </Link>
+        </div>
+
+        {teamMembers && teamMembers.length > 0 ? (
+
+          <table className="govuk-table lbh-table">
+            <thead className="govuk-table__head">
+              <tr className="govuk-table__row">
+                <th scope="col" className="govuk-table__header">
+                  Name
+                </th>
+                <th scope="col" className="govuk-table__header">
+                  Role
+                </th>
+                <th scope="col" className="govuk-table__header">
+                  Action
+                </th>
+              </tr>
+            </thead>
+            <tbody className="govuk-table__body">
+              {teamMembers.map((member, memberIndex) => (
+                <tr className="govuk-table__row lbh-list" key={member.project_member}>
+                  <td className="govuk-table__cell">{member.project_member}</td>
+                  <td className="govuk-table__cell">{member.role}</td>
+                  <td className="govuk-table__cell">
+                    <a className="lbh-link lbh-link--no-visited-state" href="#" onClick={() => { setIsModalOpen(true), setMemberToRemove(member) }}>
+                      Remove{" "}
+                    </a>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        ) : (<p className="lbh-body">No team has been assigned for this project</p>)}
+      </section>
+    </>
+  )
 };
 
 export default ProjectTeam;

--- a/components/ProjectView/ProjectTeam.tsx
+++ b/components/ProjectView/ProjectTeam.tsx
@@ -1,21 +1,22 @@
 import Router from "next/router";
 import { useState } from "react";
-import Link from 'next/link';
+import Link from "next/link";
 import { Project, ProjectMember } from "../../types";
 import style from "./ProjectView.module.scss";
-import RemovalModal from "./RemovalModal"
+import RemovalModal from "./RemovalModal";
 import { removeTeamMember, useTeamMembers } from "../../utils/projectTeam";
 import ErrorMessage from "../ErrorMessage/ErrorMessage";
+import Spinner from "../Spinner/Spinner";
 
 interface ProjectTeamProps {
-  project: Project
+  project: Project;
 }
 
 const ProjectTeam = ({ project }: ProjectTeamProps): React.ReactElement => {
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false);
   const [memberToRemove, setMemberToRemove] = useState<ProjectMember>();
 
-  const { data: teamMembers, error } = useTeamMembers(project.project_id);
+  const { data: teamMembers, error } = useTeamMembers(project.id);
 
   if (error) {
     return (
@@ -23,20 +24,29 @@ const ProjectTeam = ({ project }: ProjectTeamProps): React.ReactElement => {
     );
   }
 
+  if (!teamMembers) {
+    return <Spinner />;
+  }
+
   return (
     <>
-      <RemovalModal removalItem={memberToRemove!} isOpen={isModalOpen} onDismiss={() => setIsModalOpen(false)} onFormSubmit={async () => {
-        setIsModalOpen(false);
-        if (memberToRemove) {
-          await removeTeamMember(project.project_id, memberToRemove.id)
-          Router.reload();
-        }
-      }} />
+      <RemovalModal
+        removalItem={memberToRemove!}
+        isOpen={isModalOpen}
+        onDismiss={() => setIsModalOpen(false)}
+        onFormSubmit={async () => {
+          setIsModalOpen(false);
+          if (memberToRemove) {
+            await removeTeamMember(project.id, memberToRemove.id);
+            Router.reload();
+          }
+        }}
+      />
 
       <section className="govuk-!-margin-bottom-8">
         <div className={style.heading}>
           <h2>Project Team</h2>
-          <Link href={`/projects/${project.project_id}/team/add`}>
+          <Link href={`/projects/${project.id}/team/add`}>
             <a className="lbh-link lbh-link--no-visited-state">
               Add a new team member
             </a>
@@ -44,7 +54,6 @@ const ProjectTeam = ({ project }: ProjectTeamProps): React.ReactElement => {
         </div>
 
         {teamMembers && teamMembers.length > 0 ? (
-
           <table className="govuk-table lbh-table">
             <thead className="govuk-table__head">
               <tr className="govuk-table__row">
@@ -61,11 +70,20 @@ const ProjectTeam = ({ project }: ProjectTeamProps): React.ReactElement => {
             </thead>
             <tbody className="govuk-table__body">
               {teamMembers.map((member, memberIndex) => (
-                <tr className="govuk-table__row lbh-list" key={member.project_member}>
+                <tr
+                  className="govuk-table__row lbh-list"
+                  key={member.project_member}
+                >
                   <td className="govuk-table__cell">{member.project_member}</td>
                   <td className="govuk-table__cell">{member.role}</td>
                   <td className="govuk-table__cell">
-                    <a className="lbh-link lbh-link--no-visited-state" href="#" onClick={() => { setIsModalOpen(true), setMemberToRemove(member) }}>
+                    <a
+                      className="lbh-link lbh-link--no-visited-state"
+                      href="#"
+                      onClick={() => {
+                        setIsModalOpen(true), setMemberToRemove(member);
+                      }}
+                    >
                       Remove{" "}
                     </a>
                   </td>
@@ -73,10 +91,12 @@ const ProjectTeam = ({ project }: ProjectTeamProps): React.ReactElement => {
               ))}
             </tbody>
           </table>
-        ) : (<p className="lbh-body">No team has been assigned for this project</p>)}
+        ) : (
+          <p className="lbh-body">No team has been assigned for this project</p>
+        )}
       </section>
     </>
-  )
+  );
 };
 
 export default ProjectTeam;

--- a/components/ProjectView/ProjectView.module.scss
+++ b/components/ProjectView/ProjectView.module.scss
@@ -31,6 +31,10 @@
   }
 }
 
+.navLinkActive {
+  font-weight: $lbh-font-weight-bold;
+}
+
 .outer {
   @include govuk-media-query($from: tablet) {
     display: flex;

--- a/components/ProjectView/ProjectView.module.scss
+++ b/components/ProjectView/ProjectView.module.scss
@@ -1,0 +1,86 @@
+@import "lbh-frontend/lbh/base";
+
+.personHeader {
+  @include govuk-media-query($from: tablet) {
+    display: flex;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+  }
+}
+
+.actionsArea {
+  @include govuk-media-query($from: tablet) {
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-end;
+    align-items: center;
+  }
+}
+
+.navLink,
+.navLinkActive {
+  display: inline-block;
+  margin-bottom: 0.25rem;
+  text-decoration: none;
+  &:hover {
+    text-decoration: underline;
+  }
+  @include govuk-media-query($from: tablet) {
+    font-size: 1.2rem;
+  }
+}
+
+.outer {
+  @include govuk-media-query($from: tablet) {
+    display: flex;
+  }
+}
+
+.sticky {
+  @include govuk-media-query($from: tablet) {
+    position: sticky;
+    top: 25px;
+  }
+}
+
+.heading {
+  border-bottom: 3px solid lbh-colour("lbh-text");
+  padding-bottom: 15px;
+  margin-bottom: 10px;
+
+  a,
+  button {
+    display: block;
+    margin-top: 1rem;
+    @include lbh-body-m;
+  }
+
+  @include govuk-media-query(400px) {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+
+    a,
+    button {
+      margin-top: 0;
+    }
+  }
+}
+
+.modalActions {
+  @include govuk-media-query($from: tablet) {
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-start;
+    align-items: center;
+
+    * {
+      margin-top: 0;
+    }
+    *:last-child {
+      margin-left: 1.5rem;
+    }
+  }
+}

--- a/components/ProjectView/ProjectView.tsx
+++ b/components/ProjectView/ProjectView.tsx
@@ -5,6 +5,7 @@ import { useProject } from "../../utils/projects";
 import ErrorMessage from "../ErrorMessage/ErrorMessage";
 import Link from "next/link";
 import style from "./ProjectView.module.scss";
+import Spinner from "../Spinner/Spinner";
 
 interface Props {
   projectId: number;
@@ -39,17 +40,25 @@ const ProjectView = ({ projectId, children }: Props): React.ReactElement => {
     return <ErrorMessage />;
   }
   if (!project) {
-    return <div></div>;
+    return <Spinner />;
   }
   return (
     <>
-      <div className={`govuk-grid-row govuk-!-margin-bottom-8 `}>
-        <div className="govuk-grid-column-two-thirds">
-          <h1 className="lbh-heading-h1">Test Project</h1>
+      <div>
+        <div
+          className={`govuk-grid-row govuk-!-margin-bottom-8 ${style.personHeader} `}
+        >
+          <div className="govuk-grid-column-two-thirds">
+            <h1 className="lbh-heading-h1">{project.projectName}</h1>
+          </div>
+          <div className={`govuk-grid-column-one-third ${style.actionsArea}`}>
+            <Button
+              label="Update Project"
+              route={`/projects/${projectId}/update`}
+            />
+          </div>
         </div>
-        <div className={`govuk-grid-column-one-third ${style.actionsArea}`}>
-          <Button label="Update Project"></Button>
-        </div>
+        <hr className="lbh-divider" style={{ marginBottom: 50 }} />
       </div>
 
       <div className={`govuk-grid-row ${style.outer}`}>
@@ -67,14 +76,6 @@ const ProjectView = ({ projectId, children }: Props): React.ReactElement => {
           {typeof children === "function" ? children(project) : children}
         </div>
       </div>
-      {/* <div className="lbh-table-header">
-        <h1 className="govuk-fieldset__legend--l gov-weight-lighter">
-          Test Project
-        </h1>
-        <Button label="Update Project"></Button>
-      </div>
-      <hr className="lbh-divider"></hr>
-      {typeof children === "function" ? children(project) : children} */}
     </>
   );
 };

--- a/components/ProjectView/ProjectView.tsx
+++ b/components/ProjectView/ProjectView.tsx
@@ -1,12 +1,37 @@
+import { useRouter } from "next/router";
 import Button from "../../components/Button/Button";
 import { Project } from "../../types";
 import { useProject } from "../../utils/projects";
 import ErrorMessage from "../ErrorMessage/ErrorMessage";
+import Link from "next/link";
+import style from "./ProjectView.module.scss";
 
 interface Props {
   projectId: number;
   children?: React.ReactChild | ((arg0: Project) => React.ReactChild);
 }
+
+interface NavLinkProps {
+  href: string;
+  children: React.ReactChild;
+}
+
+const NavLink = ({ href, children }: NavLinkProps) => {
+  const router = useRouter();
+  return (
+    <li>
+      <Link href={href}>
+        <a
+          className={`lbh-link lbh-link--no-visited-state ${
+            router.asPath === href ? style.navLinkActive : style.navLink
+          }`}
+        >
+          {children}
+        </a>
+      </Link>
+    </li>
+  );
+};
 
 const ProjectView = ({ projectId, children }: Props): React.ReactElement => {
   const { data: project, error } = useProject(projectId);
@@ -18,14 +43,38 @@ const ProjectView = ({ projectId, children }: Props): React.ReactElement => {
   }
   return (
     <>
-      <div className="lbh-table-header">
+      <div className={`govuk-grid-row govuk-!-margin-bottom-8 `}>
+        <div className="govuk-grid-column-two-thirds">
+          <h1 className="lbh-heading-h1">Test Project</h1>
+        </div>
+        <div className={`govuk-grid-column-one-third ${style.actionsArea}`}>
+          <Button label="Update Project"></Button>
+        </div>
+      </div>
+
+      <div className={`govuk-grid-row ${style.outer}`}>
+        <div className="govuk-grid-column-one-quarter">
+          <nav className={style.sticky}>
+            <ul className="lbh-list">
+              <NavLink href={`/projects/${projectId}/details`}>Details</NavLink>
+              <NavLink href={`/projects/${projectId}/links`}>Links</NavLink>
+              <NavLink href={`/projects/${projectId}/team`}>Team</NavLink>
+            </ul>
+          </nav>
+        </div>
+        <div className="govuk-grid-column-three-quarters">
+          {" "}
+          {typeof children === "function" ? children(project) : children}
+        </div>
+      </div>
+      {/* <div className="lbh-table-header">
         <h1 className="govuk-fieldset__legend--l gov-weight-lighter">
           Test Project
         </h1>
         <Button label="Update Project"></Button>
       </div>
       <hr className="lbh-divider"></hr>
-      {typeof children === "function" ? children(project) : children}
+      {typeof children === "function" ? children(project) : children} */}
     </>
   );
 };

--- a/components/ProjectView/RemovalModal.spec.tsx
+++ b/components/ProjectView/RemovalModal.spec.tsx
@@ -1,0 +1,43 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { mockedProjectLink } from "../../factories/projectLinks";
+import { mockedProjectMember } from "../../factories/projectMembers";
+import RemovalModal from "./RemovalModal";
+
+describe('RemovalModal component', () => {
+    it('displays the correct title if the item to be removed is a team member', () => {
+        render(
+            <RemovalModal isOpen={true} onDismiss={jest.fn()}
+                onFormSubmit={jest.fn()} removalItem={mockedProjectMember} />);
+
+        expect(screen.getByText("You are about to remove this team member"));
+    })
+
+    it('displays the correct title if the item to be removed is a link', () => {
+        render(
+            <RemovalModal isOpen={true} onDismiss={jest.fn()}
+                onFormSubmit={jest.fn()} removalItem={mockedProjectLink} />);
+
+        expect(screen.getByText("You are about to remove this link"));
+    })
+
+    it('calls onFormSubmit when confirm button is clicked', () => {
+        const submitFunction = jest.fn();
+        render(
+            <RemovalModal isOpen={true} onDismiss={jest.fn()}
+                onFormSubmit={submitFunction} removalItem={mockedProjectLink} />);
+
+        fireEvent.click(screen.getByText("Yes, remove"));
+        expect(submitFunction).toBeCalled();
+    })
+
+    it('calls onDismiss when cancel button is clicked', () => {
+        const cancelFunction = jest.fn();
+        render(
+            <RemovalModal isOpen={true} onDismiss={cancelFunction}
+                onFormSubmit={jest.fn()} removalItem={mockedProjectLink} />);
+
+        fireEvent.click(screen.getByText("Cancel"));
+        expect(cancelFunction).toBeCalled();
+    })
+
+})

--- a/components/ProjectView/RemovalModal.tsx
+++ b/components/ProjectView/RemovalModal.tsx
@@ -15,9 +15,9 @@ const RemovalModal = ({
   onFormSubmit,
   removalItem,
 }: Props): React.ReactElement => {
-  //const title = if (removalItem) {'member_id' in removalItem ? "You are about to remove this team member" : "You are about to remove this link"}
+  const title = removalItem && 'member_id' in removalItem ? "You are about to remove this team member" : "You are about to remove this link"
   return (
-    <Modal isOpen={isOpen} onDismiss={onDismiss} title={"title"}>
+    <Modal isOpen={isOpen} onDismiss={onDismiss} title={title}>
       <p className="lbh-body">Are you sure you want to do this?</p>
       <div className={style.modalActions}>
         <button onClick={onFormSubmit} className="govuk-button lbh-button">

--- a/components/ProjectView/RemovalModal.tsx
+++ b/components/ProjectView/RemovalModal.tsx
@@ -1,0 +1,36 @@
+import { ProjectLink, ProjectMember } from "../../types";
+import Modal from "../Modal/Modal";
+import style from "./ProjectView.module.scss";
+
+interface Props {
+    isOpen: boolean;
+    onDismiss: () => void;
+    onFormSubmit: () => void;
+    removalItem: ProjectLink | ProjectMember;
+
+}
+
+const RemovalModal = ({ isOpen, onDismiss, onFormSubmit, removalItem }: Props): React.ReactElement => {
+    //const title = if (removalItem) {'member_id' in removalItem ? "You are about to remove this team member" : "You are about to remove this link"}
+    return (
+        <Modal isOpen={isOpen} onDismiss={onDismiss} title={"title"}>
+            <p className="lbh-body">
+                Are you sure you want to do this?
+            </p>
+            <div className={style.modalActions}>
+                <button onClick={onFormSubmit} className="govuk-button lbh-button">
+                    Yes, remove
+                </button>
+                <a
+                    className="lbh-link lbh-link--no-visited-state"
+                    href="#"
+                    onClick={onDismiss}
+                >
+                    Cancel
+                </a>
+            </div>
+        </Modal>
+    )
+}
+
+export default RemovalModal;

--- a/components/ProjectView/RemovalModal.tsx
+++ b/components/ProjectView/RemovalModal.tsx
@@ -3,34 +3,36 @@ import Modal from "../Modal/Modal";
 import style from "./ProjectView.module.scss";
 
 interface Props {
-    isOpen: boolean;
-    onDismiss: () => void;
-    onFormSubmit: () => void;
-    removalItem: ProjectLink | ProjectMember;
-
+  isOpen: boolean;
+  onDismiss: () => void;
+  onFormSubmit: () => void;
+  removalItem: ProjectLink | ProjectMember;
 }
 
-const RemovalModal = ({ isOpen, onDismiss, onFormSubmit, removalItem }: Props): React.ReactElement => {
-    //const title = if (removalItem) {'member_id' in removalItem ? "You are about to remove this team member" : "You are about to remove this link"}
-    return (
-        <Modal isOpen={isOpen} onDismiss={onDismiss} title={"title"}>
-            <p className="lbh-body">
-                Are you sure you want to do this?
-            </p>
-            <div className={style.modalActions}>
-                <button onClick={onFormSubmit} className="govuk-button lbh-button">
-                    Yes, remove
-                </button>
-                <a
-                    className="lbh-link lbh-link--no-visited-state"
-                    href="#"
-                    onClick={onDismiss}
-                >
-                    Cancel
-                </a>
-            </div>
-        </Modal>
-    )
-}
+const RemovalModal = ({
+  isOpen,
+  onDismiss,
+  onFormSubmit,
+  removalItem,
+}: Props): React.ReactElement => {
+  //const title = if (removalItem) {'member_id' in removalItem ? "You are about to remove this team member" : "You are about to remove this link"}
+  return (
+    <Modal isOpen={isOpen} onDismiss={onDismiss} title={"title"}>
+      <p className="lbh-body">Are you sure you want to do this?</p>
+      <div className={style.modalActions}>
+        <button onClick={onFormSubmit} className="govuk-button lbh-button">
+          Yes, remove
+        </button>
+        <a
+          className="lbh-link lbh-link--no-visited-state"
+          href="#"
+          onClick={onDismiss}
+        >
+          Cancel
+        </a>
+      </div>
+    </Modal>
+  );
+};
 
 export default RemovalModal;

--- a/components/ProjectView/__snapshots__/ProjectDetails.spec.tsx.snap
+++ b/components/ProjectView/__snapshots__/ProjectDetails.spec.tsx.snap
@@ -17,7 +17,7 @@ exports[`ProjectDetails component should render a ProjectDetails component with 
         <dd
           class="govuk-summary-list__value"
         >
-          Test Value
+          Someone
         </dd>
       </div>
       <div
@@ -26,7 +26,7 @@ exports[`ProjectDetails component should render a ProjectDetails component with 
         <dt
           class="govuk-summary-list__key"
         >
-          Stage
+          Phase
         </dt>
         <dd
           class="govuk-summary-list__value"
@@ -60,6 +60,34 @@ exports[`ProjectDetails component should render a ProjectDetails component with 
           class="govuk-summary-list__value"
         >
           Tech
+        </dd>
+      </div>
+      <div
+        class="govuk-summary-list__row"
+      >
+        <dt
+          class="govuk-summary-list__key"
+        >
+          Priority
+        </dt>
+        <dd
+          class="govuk-summary-list__value"
+        >
+          Extreme
+        </dd>
+      </div>
+      <div
+        class="govuk-summary-list__row"
+      >
+        <dt
+          class="govuk-summary-list__key"
+        >
+          Product Users
+        </dt>
+        <dd
+          class="govuk-summary-list__value"
+        >
+          Noone
         </dd>
       </div>
       <div

--- a/components/ProjectView/__snapshots__/ProjectLinks.spec.tsx.snap
+++ b/components/ProjectView/__snapshots__/ProjectLinks.spec.tsx.snap
@@ -2,25 +2,15 @@
 
 exports[`ProjectLinks component should render a ProjectLinks component with the correct data 1`] = `
 <DocumentFragment>
-  <div>
-    <dl
-      class="govuk-summary-list lbh-summary-list"
+  <span
+    class="govuk-error-message"
+  >
+    <span
+      class="govuk-visually-hidden"
     >
-      <div
-        class="govuk-summary-list__row"
-      >
-        <dt
-          class="govuk-summary-list__key"
-        >
-          Foo
-        </dt>
-        <dd
-          class="govuk-summary-list__value"
-        >
-          fake link
-        </dd>
-      </div>
-    </dl>
-  </div>
+      Error:
+    </span>
+     There was a problem with getting the project's links.
+  </span>
 </DocumentFragment>
 `;

--- a/components/ProjectView/__snapshots__/ProjectTeam.spec.tsx.snap
+++ b/components/ProjectView/__snapshots__/ProjectTeam.spec.tsx.snap
@@ -2,25 +2,15 @@
 
 exports[`ProjectTeam component should render a ProjectTeam component with the correct data 1`] = `
 <DocumentFragment>
-  <div>
-    <dl
-      class="govuk-summary-list lbh-summary-list"
+  <span
+    class="govuk-error-message"
+  >
+    <span
+      class="govuk-visually-hidden"
     >
-      <div
-        class="govuk-summary-list__row"
-      >
-        <dt
-          class="govuk-summary-list__key"
-        >
-          Julius Caesar
-        </dt>
-        <dd
-          class="govuk-summary-list__value"
-        >
-          Delivery Manager
-        </dd>
-      </div>
-    </dl>
-  </div>
+      Error:
+    </span>
+     There was a problem with getting the project's team members.
+  </span>
 </DocumentFragment>
 `;

--- a/components/ProjectsTable/ProjectsTable.tsx
+++ b/components/ProjectsTable/ProjectsTable.tsx
@@ -1,14 +1,16 @@
+import Link from "next/link";
 import { Project } from "../../types";
 
 const ProjectEntry = (project: Project): React.ReactElement => {
-  const { project_name, stage, size, type } = project;
+  const { id, projectName, phase, size } = project;
   return (
-    <tr className="govuk-table__row">
-      <td className="govuk-table__cell">{project_name}</td>
-      <td className="govuk-table__cell">{stage}</td>
-      <td className="govuk-table__cell">{size}</td>
-      <td className="govuk-table__cell">{type}</td>
-    </tr>
+    <Link href={`/projects/${id}/details`}>
+      <tr className="govuk-table__row govuk-table__row--clickable">
+        <td className="govuk-table__cell">{projectName}</td>
+        <td className="govuk-table__cell">{phase}</td>
+        <td className="govuk-table__cell">{size}</td>
+      </tr>
+    </Link>
   );
 };
 
@@ -17,29 +19,27 @@ const ProjectsTable = ({
 }: {
   projects: Project[];
 }): React.ReactElement => (
-  <table className="govuk-table lbh-table">
+  <table className="govuk-table">
     <thead className="govuk-table__head">
       <tr className="govuk-table__row">
         <th scope="col" className="govuk-table__header">
           Project Name
         </th>
         <th scope="col" className="govuk-table__header">
-          Stage
+          Phase
         </th>
         <th scope="col" className="govuk-table__header">
           Size
-        </th>
-        <th scope="col" className="govuk-table__header">
-          Project Type
         </th>
       </tr>
     </thead>
     <tbody className="govuk-table__body">
       {projects.map((result) => (
-        <ProjectEntry key={result.project_id} {...result} />
+        <ProjectEntry key={result.id} {...result} />
       ))}
     </tbody>
   </table>
 );
 
 export default ProjectsTable;
+

--- a/components/ProjectsTable/__snapshots__/ProjectsTable.spec.tsx.snap
+++ b/components/ProjectsTable/__snapshots__/ProjectsTable.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`ProjectsTable component should render a list of projects 1`] = `
 <DocumentFragment>
   <table
-    class="govuk-table lbh-table"
+    class="govuk-table"
   >
     <thead
       class="govuk-table__head"
@@ -21,7 +21,7 @@ exports[`ProjectsTable component should render a list of projects 1`] = `
           class="govuk-table__header"
           scope="col"
         >
-          Stage
+          Phase
         </th>
         <th
           class="govuk-table__header"
@@ -29,19 +29,13 @@ exports[`ProjectsTable component should render a list of projects 1`] = `
         >
           Size
         </th>
-        <th
-          class="govuk-table__header"
-          scope="col"
-        >
-          Project Type
-        </th>
       </tr>
     </thead>
     <tbody
       class="govuk-table__body"
     >
       <tr
-        class="govuk-table__row"
+        class="govuk-table__row govuk-table__row--clickable"
       >
         <td
           class="govuk-table__cell"
@@ -57,11 +51,6 @@ exports[`ProjectsTable component should render a list of projects 1`] = `
           class="govuk-table__cell"
         >
           Large
-        </td>
-        <td
-          class="govuk-table__cell"
-        >
-          Tech
         </td>
       </tr>
     </tbody>

--- a/components/Spinner/Spinner.tsx
+++ b/components/Spinner/Spinner.tsx
@@ -1,28 +1,28 @@
 const Spinner = (): React.ReactElement => (
-    <svg
-        width="50"
-        height="50"
-        viewBox="0 0 42 42"
-        xmlns="http://www.w3.org/2000/svg"
-        stroke="#00703c"
-        style={{ display: 'block', margin: 'auto' }}
-    >
-        <g fill="none" fillRule="evenodd">
-            <g transform="translate(3 3)" strokeWidth="5">
-                <circle strokeOpacity=".5" cx="18" cy="18" r="18" />
-                <path d="M36 18c0-9.94-8.06-18-18-18" transform="rotate(112.708 18 18)">
-                    <animateTransform
-                        attributeName="transform"
-                        type="rotate"
-                        from="0 18 18"
-                        to="360 18 18"
-                        dur="1s"
-                        repeatCount="indefinite"
-                    />
-                </path>
-            </g>
-        </g>
-    </svg>
+  <svg
+    width="50"
+    height="50"
+    viewBox="0 0 42 42"
+    xmlns="http://www.w3.org/2000/svg"
+    stroke="#00703c"
+    style={{ display: "block", margin: "auto" }}
+  >
+    <g fill="none" fillRule="evenodd">
+      <g transform="translate(3 3)" strokeWidth="5">
+        <circle strokeOpacity=".5" cx="18" cy="18" r="18" />
+        <path d="M36 18c0-9.94-8.06-18-18-18" transform="rotate(112.708 18 18)">
+          <animateTransform
+            attributeName="transform"
+            type="rotate"
+            from="0 18 18"
+            to="360 18 18"
+            dur="1s"
+            repeatCount="indefinite"
+          />
+        </path>
+      </g>
+    </g>
+  </svg>
 );
 
 export default Spinner;

--- a/components/Spinner/Spinner.tsx
+++ b/components/Spinner/Spinner.tsx
@@ -1,0 +1,28 @@
+const Spinner = (): React.ReactElement => (
+    <svg
+        width="50"
+        height="50"
+        viewBox="0 0 42 42"
+        xmlns="http://www.w3.org/2000/svg"
+        stroke="#00703c"
+        style={{ display: 'block', margin: 'auto' }}
+    >
+        <g fill="none" fillRule="evenodd">
+            <g transform="translate(3 3)" strokeWidth="5">
+                <circle strokeOpacity=".5" cx="18" cy="18" r="18" />
+                <path d="M36 18c0-9.94-8.06-18-18-18" transform="rotate(112.708 18 18)">
+                    <animateTransform
+                        attributeName="transform"
+                        type="rotate"
+                        from="0 18 18"
+                        to="360 18 18"
+                        dur="1s"
+                        repeatCount="indefinite"
+                    />
+                </path>
+            </g>
+        </g>
+    </svg>
+);
+
+export default Spinner;

--- a/data/ProjectPriority.ts
+++ b/data/ProjectPriority.ts
@@ -1,0 +1,14 @@
+export default [
+  {
+    text: "Medium priority",
+    value: "Medium priority",
+  },
+  {
+    text: "High priority",
+    value: "High priority",
+  },
+  {
+    text: "Urgent priority",
+    value: "Urgent priority",
+  },
+];

--- a/data/projectPhases.ts
+++ b/data/projectPhases.ts
@@ -1,0 +1,14 @@
+export default [
+  {
+    text: "Discovery",
+    value: "Discovery",
+  },
+  {
+    text: "Build",
+    value: "Build",
+  },
+  {
+    text: "Support",
+    value: "Spport",
+  },
+];

--- a/data/projectSizes.ts
+++ b/data/projectSizes.ts
@@ -1,0 +1,22 @@
+export default [
+  {
+    text: "Extra Small",
+    value: "Extra Small",
+  },
+  {
+    text: "Small",
+    value: "Small",
+  },
+  {
+    text: "Medium",
+    value: "Medium",
+  },
+  {
+    text: "Large",
+    value: "Large",
+  },
+  {
+    text: "Extra Large",
+    value: "Extra Large",
+  },
+];

--- a/factories/projectLinks.ts
+++ b/factories/projectLinks.ts
@@ -1,0 +1,14 @@
+import { Factory } from "fishery";
+import { ProjectLink } from "../types";
+
+export const projectLinkFactory = Factory.define<ProjectLink>(
+    ({ sequence }) => ({
+        id: sequence,
+        project_id: sequence + 1,
+        type: "Google Drive",
+        link: "https://fakelink.com",
+    })
+);
+
+export const mockedProjectLink = projectLinkFactory.build();
+export const mockedProjectsLinks = [projectLinkFactory.build()];

--- a/factories/projectMembers.ts
+++ b/factories/projectMembers.ts
@@ -1,0 +1,15 @@
+import { Factory } from "fishery";
+import { ProjectMember } from "../types";
+
+export const projectMemberFactory = Factory.define<ProjectMember>(
+  ({ sequence }) => ({
+    id: sequence,
+    member_id: sequence + 1,
+    project_id: sequence + 2,
+    project_member: "Some Person",
+    role: "Developer",
+  })
+);
+
+export const mockedProjectMember = projectMemberFactory.build();
+export const mockedProjectsMembers = [projectMemberFactory.build()];

--- a/factories/projects.ts
+++ b/factories/projects.ts
@@ -2,20 +2,16 @@ import { Factory } from "fishery";
 import { Project } from "../types";
 
 export const projectFactory = Factory.define<Project>(({ sequence }) => ({
-  project_id: sequence,
-  project_name: "Test Project",
+  id: sequence,
+  projectName: "Test Project",
   description: "A project with many details",
-  stage: "Discovery",
+  projectContact: "Someone",
+  phase: "Discovery",
   size: "Large",
-  type: "Tech",
-  project_dependencies: "none",
-  project_links: [
-    {
-      name: "Foo",
-      link: "fake link",
-    },
-  ],
-  project_team: [{ name: "Julius Caesar", role: "Delivery Manager" }],
+  category: "Tech",
+  priority: "Extreme",
+  productUsers: "Noone",
+  dependencies: "none",
 }));
 
 export const mockedProject = projectFactory.build();

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "format": "prettier '**/*.{js,jsx,ts,tsx,css,scss,md}' --write --list-different"
   },
   "dependencies": {
+    "@reach/dialog": "^0.16.0",
     "axios": "^0.21.1",
     "classnames": "^2.3.1",
     "cookie": "^0.4.1",

--- a/pages/api/projects/[id]/index.ts
+++ b/pages/api/projects/[id]/index.ts
@@ -1,7 +1,7 @@
 import type { NextApiRequest, NextApiResponse, NextApiHandler } from "next";
 
 import { StatusCodes } from "http-status-codes";
-import { getProject } from "../../../../api/projects";
+import { getProject, updateProject } from "../../../../api/projects";
 
 const endpoint: NextApiHandler = async (
   req: NextApiRequest,
@@ -25,6 +25,20 @@ const endpoint: NextApiHandler = async (
           : res
               .status(StatusCodes.INTERNAL_SERVER_ERROR)
               .json({ message: "Unable to get the Project" });
+      }
+      break;
+
+    case "PATCH":
+      try {
+        console.log("data is: " + req.body);
+        const data = await updateProject(req.body);
+        res.status(StatusCodes.OK).json(data);
+      } catch (error) {
+        console.error("Project patch error:", error?.response?.data);
+        console.error("Project patch request:", req);
+        res
+          .status(StatusCodes.INTERNAL_SERVER_ERROR)
+          .json({ message: "Unable to update project" });
       }
       break;
 

--- a/pages/api/projects/[id]/links/index.ts
+++ b/pages/api/projects/[id]/links/index.ts
@@ -2,71 +2,73 @@ import type { NextApiRequest, NextApiResponse, NextApiHandler } from "next";
 
 import { StatusCodes } from "http-status-codes";
 import { isAuthorised } from "../../../../../utils/auth";
-import { addProjectLink, getLinksByProject, removeProjectLink } from "../../../../../api/projectLinks";
-
-
+import {
+  addProjectLink,
+  getLinksByProject,
+  removeProjectLink,
+} from "../../../../../api/projectLinks";
 
 const endpoint: NextApiHandler = async (
-    req: NextApiRequest,
-    res: NextApiResponse
+  req: NextApiRequest,
+  res: NextApiResponse
 ) => {
-    const user = isAuthorised(req);
-    if (!user) {
-        return res.status(StatusCodes.UNAUTHORIZED).end();
-    }
-    if (!user.isAuthorised) {
-        return res.status(StatusCodes.FORBIDDEN).end();
-    }
-    switch (req.method) {
-        case "GET":
-            try {
-                const data = await getLinksByProject(parseInt(req.query.id as string));
-                res.status(StatusCodes.OK).json(data)
-            } catch (error) {
-                console.error("Project link get error:", error?.response?.data);
-                error?.response?.status === StatusCodes.NOT_FOUND
-                    ? res
-                        .status(StatusCodes.NOT_FOUND)
-                        .json({ message: "Project links Not Found" })
-                    : res
-                        .status(StatusCodes.INTERNAL_SERVER_ERROR)
-                        .json({ message: "Unable to get the project links" });
-            }
-            break;
-        case 'POST':
-            try {
-                await addProjectLink(parseInt(req.query.id as string), req.body);
-                res.status(StatusCodes.CREATED).end();
-            } catch (error) {
-                console.error('Project link post error:', error?.response?.data);
-                error?.response?.status === StatusCodes.NOT_FOUND
-                res
-                    .status(StatusCodes.INTERNAL_SERVER_ERROR)
-                    .json({ message: 'Unable to add the project link' });
-            }
-            break;
+  const user = isAuthorised(req);
+  if (!user) {
+    return res.status(StatusCodes.UNAUTHORIZED).end();
+  }
+  if (!user.isAuthorised) {
+    return res.status(StatusCodes.FORBIDDEN).end();
+  }
+  switch (req.method) {
+    case "GET":
+      try {
+        const data = await getLinksByProject(parseInt(req.query.id as string));
+        res.status(StatusCodes.OK).json(data);
+      } catch (error) {
+        console.error("Project link get error:", error?.response?.data);
+        error?.response?.status === StatusCodes.NOT_FOUND
+          ? res
+              .status(StatusCodes.NOT_FOUND)
+              .json({ message: "Project links Not Found" })
+          : res
+              .status(StatusCodes.INTERNAL_SERVER_ERROR)
+              .json({ message: "Unable to get the project links" });
+      }
+      break;
+    case "POST":
+      try {
+        await addProjectLink(parseInt(req.query.id as string), req.body);
+        res.status(StatusCodes.CREATED).end();
+      } catch (error) {
+        console.error("Project link post error:", error?.response?.data);
+        error?.response?.status === StatusCodes.NOT_FOUND;
+        res
+          .status(StatusCodes.INTERNAL_SERVER_ERROR)
+          .json({ message: "Unable to add the project link" });
+      }
+      break;
 
-        case 'DELETE':
-            try {
-                await removeProjectLink(parseInt(req.query.link_id as string));
-                res.status(StatusCodes.OK).end();
-            } catch (error) {
-                console.error('Project link delete error:', error?.response?.data);
-                error?.response?.status === StatusCodes.NOT_FOUND
-                    ? res.status(StatusCodes.NOT_FOUND).json({
-                        message: `Project link not found with ID: ${req.query.link_id}.`,
-                    })
-                    : res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
-                        message: `Unable to remove the project link with ID: ${req.query.link_id}.`,
-                    });
-            }
-            break;
+    case "DELETE":
+      try {
+        await removeProjectLink(parseInt(req.query.link_id as string));
+        res.status(StatusCodes.OK).end();
+      } catch (error) {
+        console.error("Project link delete error:", error?.response?.data);
+        error?.response?.status === StatusCodes.NOT_FOUND
+          ? res.status(StatusCodes.NOT_FOUND).json({
+              message: `Project link not found with ID: ${req.query.link_id}.`,
+            })
+          : res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+              message: `Unable to remove the project link with ID: ${req.query.link_id}.`,
+            });
+      }
+      break;
 
-        default:
-            res
-                .status(StatusCodes.BAD_REQUEST)
-                .json({ message: "Invalid request method" });
-    }
+    default:
+      res
+        .status(StatusCodes.BAD_REQUEST)
+        .json({ message: "Invalid request method" });
+  }
 };
 
 export default endpoint;

--- a/pages/api/projects/[id]/links/index.ts
+++ b/pages/api/projects/[id]/links/index.ts
@@ -1,0 +1,72 @@
+import type { NextApiRequest, NextApiResponse, NextApiHandler } from "next";
+
+import { StatusCodes } from "http-status-codes";
+import { isAuthorised } from "../../../../../utils/auth";
+import { addProjectLink, getLinksByProject, removeProjectLink } from "../../../../../api/projectLinks";
+
+
+
+const endpoint: NextApiHandler = async (
+    req: NextApiRequest,
+    res: NextApiResponse
+) => {
+    const user = isAuthorised(req);
+    if (!user) {
+        return res.status(StatusCodes.UNAUTHORIZED).end();
+    }
+    if (!user.isAuthorised) {
+        return res.status(StatusCodes.FORBIDDEN).end();
+    }
+    switch (req.method) {
+        case "GET":
+            try {
+                const data = await getLinksByProject(parseInt(req.query.id as string));
+                res.status(StatusCodes.OK).json(data)
+            } catch (error) {
+                console.error("Project link get error:", error?.response?.data);
+                error?.response?.status === StatusCodes.NOT_FOUND
+                    ? res
+                        .status(StatusCodes.NOT_FOUND)
+                        .json({ message: "Project links Not Found" })
+                    : res
+                        .status(StatusCodes.INTERNAL_SERVER_ERROR)
+                        .json({ message: "Unable to get the project links" });
+            }
+            break;
+        case 'POST':
+            try {
+                await addProjectLink(parseInt(req.query.id as string), req.body);
+                res.status(StatusCodes.CREATED).end();
+            } catch (error) {
+                console.error('Project link post error:', error?.response?.data);
+                error?.response?.status === StatusCodes.NOT_FOUND
+                res
+                    .status(StatusCodes.INTERNAL_SERVER_ERROR)
+                    .json({ message: 'Unable to add the project link' });
+            }
+            break;
+
+        case 'DELETE':
+            try {
+                await removeProjectLink(parseInt(req.query.link_id as string));
+                res.status(StatusCodes.OK).end();
+            } catch (error) {
+                console.error('Project link delete error:', error?.response?.data);
+                error?.response?.status === StatusCodes.NOT_FOUND
+                    ? res.status(StatusCodes.NOT_FOUND).json({
+                        message: `Project link not found with ID: ${req.query.link_id}.`,
+                    })
+                    : res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+                        message: `Unable to remove the project link with ID: ${req.query.link_id}.`,
+                    });
+            }
+            break;
+
+        default:
+            res
+                .status(StatusCodes.BAD_REQUEST)
+                .json({ message: "Invalid request method" });
+    }
+};
+
+export default endpoint;

--- a/pages/api/projects/[id]/team/index.ts
+++ b/pages/api/projects/[id]/team/index.ts
@@ -2,69 +2,72 @@ import type { NextApiRequest, NextApiResponse, NextApiHandler } from "next";
 
 import { StatusCodes } from "http-status-codes";
 import { isAuthorised } from "../../../../../utils/auth";
-import { addTeamMember, getTeamByProject, removeTeamMember } from "../../../../../api/projectTeam";
-
+import {
+  addTeamMember,
+  getTeamByProject,
+  removeTeamMember,
+} from "../../../../../api/projectTeam";
 
 const endpoint: NextApiHandler = async (
-    req: NextApiRequest,
-    res: NextApiResponse
+  req: NextApiRequest,
+  res: NextApiResponse
 ) => {
-    const user = isAuthorised(req);
-    if (!user) {
-        return res.status(StatusCodes.UNAUTHORIZED).end();
-    }
-    if (!user.isAuthorised) {
-        return res.status(StatusCodes.FORBIDDEN).end();
-    }
-    switch (req.method) {
-        case "GET":
-            try {
-                const data = await getTeamByProject(parseInt(req.query.id as string));
-                res.status(StatusCodes.OK).json(data)
-            } catch (error) {
-                console.error("Project team get error:", error?.response?.data);
-                error?.response?.status === StatusCodes.NOT_FOUND
-                    ? res
-                        .status(StatusCodes.NOT_FOUND)
-                        .json({ message: "Project team Not Found" })
-                    : res
-                        .status(StatusCodes.INTERNAL_SERVER_ERROR)
-                        .json({ message: "Unable to get the project team" });
-            }
-            break;
-        case 'POST':
-            try {
-                await addTeamMember(parseInt(req.query.id as string), req.body);
-                res.status(StatusCodes.CREATED).end();
-            } catch (error) {
-                console.error('Team member post error:', error?.response?.data);
-                error?.response?.status === StatusCodes.NOT_FOUND
-                res
-                    .status(StatusCodes.INTERNAL_SERVER_ERROR)
-                    .json({ message: 'Unable to add the team member' });
-            }
-            break;
-        case 'DELETE':
-            try {
-                await removeTeamMember(parseInt(req.query.team_member_id as string));
-                res.status(StatusCodes.OK).end();
-            } catch (error) {
-                console.error('Team member delete error:', error?.response?.data);
-                error?.response?.status === StatusCodes.NOT_FOUND
-                    ? res.status(StatusCodes.NOT_FOUND).json({
-                        message: `Team member not found with ID: ${req.query.team_member_id}.`,
-                    })
-                    : res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
-                        message: `Unable to remove the team member with ID: ${req.query.team_member_id}.`,
-                    });
-            }
-            break;
+  const user = isAuthorised(req);
+  if (!user) {
+    return res.status(StatusCodes.UNAUTHORIZED).end();
+  }
+  if (!user.isAuthorised) {
+    return res.status(StatusCodes.FORBIDDEN).end();
+  }
+  switch (req.method) {
+    case "GET":
+      try {
+        const data = await getTeamByProject(parseInt(req.query.id as string));
+        res.status(StatusCodes.OK).json(data);
+      } catch (error) {
+        console.error("Project team get error:", error?.response?.data);
+        error?.response?.status === StatusCodes.NOT_FOUND
+          ? res
+              .status(StatusCodes.NOT_FOUND)
+              .json({ message: "Project team Not Found" })
+          : res
+              .status(StatusCodes.INTERNAL_SERVER_ERROR)
+              .json({ message: "Unable to get the project team" });
+      }
+      break;
+    case "POST":
+      try {
+        await addTeamMember(parseInt(req.query.id as string), req.body);
+        res.status(StatusCodes.CREATED).end();
+      } catch (error) {
+        console.error("Team member post error:", error?.response?.data);
+        error?.response?.status === StatusCodes.NOT_FOUND;
+        res
+          .status(StatusCodes.INTERNAL_SERVER_ERROR)
+          .json({ message: "Unable to add the team member" });
+      }
+      break;
+    case "DELETE":
+      try {
+        await removeTeamMember(parseInt(req.query.team_member_id as string));
+        res.status(StatusCodes.OK).end();
+      } catch (error) {
+        console.error("Team member delete error:", error?.response?.data);
+        error?.response?.status === StatusCodes.NOT_FOUND
+          ? res.status(StatusCodes.NOT_FOUND).json({
+              message: `Team member not found with ID: ${req.query.team_member_id}.`,
+            })
+          : res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+              message: `Unable to remove the team member with ID: ${req.query.team_member_id}.`,
+            });
+      }
+      break;
 
-        default:
-            res
-                .status(StatusCodes.BAD_REQUEST)
-                .json({ message: "Invalid request method" });
-    }
+    default:
+      res
+        .status(StatusCodes.BAD_REQUEST)
+        .json({ message: "Invalid request method" });
+  }
 };
 
 export default endpoint;

--- a/pages/api/projects/[id]/team/index.ts
+++ b/pages/api/projects/[id]/team/index.ts
@@ -1,0 +1,70 @@
+import type { NextApiRequest, NextApiResponse, NextApiHandler } from "next";
+
+import { StatusCodes } from "http-status-codes";
+import { isAuthorised } from "../../../../../utils/auth";
+import { addTeamMember, getTeamByProject, removeTeamMember } from "../../../../../api/projectTeam";
+
+
+const endpoint: NextApiHandler = async (
+    req: NextApiRequest,
+    res: NextApiResponse
+) => {
+    const user = isAuthorised(req);
+    if (!user) {
+        return res.status(StatusCodes.UNAUTHORIZED).end();
+    }
+    if (!user.isAuthorised) {
+        return res.status(StatusCodes.FORBIDDEN).end();
+    }
+    switch (req.method) {
+        case "GET":
+            try {
+                const data = await getTeamByProject(parseInt(req.query.id as string));
+                res.status(StatusCodes.OK).json(data)
+            } catch (error) {
+                console.error("Project team get error:", error?.response?.data);
+                error?.response?.status === StatusCodes.NOT_FOUND
+                    ? res
+                        .status(StatusCodes.NOT_FOUND)
+                        .json({ message: "Project team Not Found" })
+                    : res
+                        .status(StatusCodes.INTERNAL_SERVER_ERROR)
+                        .json({ message: "Unable to get the project team" });
+            }
+            break;
+        case 'POST':
+            try {
+                await addTeamMember(parseInt(req.query.id as string), req.body);
+                res.status(StatusCodes.CREATED).end();
+            } catch (error) {
+                console.error('Team member post error:', error?.response?.data);
+                error?.response?.status === StatusCodes.NOT_FOUND
+                res
+                    .status(StatusCodes.INTERNAL_SERVER_ERROR)
+                    .json({ message: 'Unable to add the team member' });
+            }
+            break;
+        case 'DELETE':
+            try {
+                await removeTeamMember(parseInt(req.query.team_member_id as string));
+                res.status(StatusCodes.OK).end();
+            } catch (error) {
+                console.error('Team member delete error:', error?.response?.data);
+                error?.response?.status === StatusCodes.NOT_FOUND
+                    ? res.status(StatusCodes.NOT_FOUND).json({
+                        message: `Team member not found with ID: ${req.query.team_member_id}.`,
+                    })
+                    : res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+                        message: `Unable to remove the team member with ID: ${req.query.team_member_id}.`,
+                    });
+            }
+            break;
+
+        default:
+            res
+                .status(StatusCodes.BAD_REQUEST)
+                .json({ message: "Invalid request method" });
+    }
+};
+
+export default endpoint;

--- a/pages/projects/[id]/details.tsx
+++ b/pages/projects/[id]/details.tsx
@@ -2,11 +2,14 @@ import ProjectDetails from "../../../components/ProjectView/ProjectDetails";
 import ProjectView from "../../../components/ProjectView/ProjectView";
 import ProjectLinks from "../../../components/ProjectView/ProjectLinks";
 import ProjectTeam from "../../../components/ProjectView/ProjectTeam";
+import { useRouter } from "next/router";
 
 const ProjectPage = (): React.ReactElement => {
+  const { query } = useRouter();
+  const projectId = Number(query.id);
   return (
     <>
-      <ProjectView projectId={1}>
+      <ProjectView projectId={projectId}>
         {(project) => (
           <>
             <h2 className="lbh-heading-h2">Description</h2>

--- a/pages/projects/[id]/details.tsx
+++ b/pages/projects/[id]/details.tsx
@@ -13,10 +13,6 @@ const ProjectPage = (): React.ReactElement => {
             <p className="lbh-body-m">{project.description}</p>
             <h2 className="lbh-heading-h2">Project details</h2>
             <ProjectDetails project={project}></ProjectDetails>
-            <h2 className="lbh-heading-h2">Related links and information</h2>
-            <ProjectLinks content={project.project_links!}></ProjectLinks>
-            <h2 className="lbh-heading-h2">Team</h2>
-            <ProjectTeam content={project.project_team!}></ProjectTeam>
           </>
         )}
       </ProjectView>

--- a/pages/projects/[id]/links.tsx
+++ b/pages/projects/[id]/links.tsx
@@ -1,16 +1,17 @@
 import ProjectView from "../../../components/ProjectView/ProjectView";
 import ProjectLinks from "../../../components/ProjectView/ProjectLinks";
+import { useRouter } from "next/router";
 
 const ProjectLinkPage = (): React.ReactElement => {
-    return (
-        <>
-            <ProjectView projectId={1}>
-                {(project) => (
-                    <ProjectLinks project={project}></ProjectLinks>
-                )}
-            </ProjectView>
-        </>
-    );
+  const { query } = useRouter();
+  const projectId = Number(query.id);
+  return (
+    <>
+      <ProjectView projectId={projectId}>
+        {(project) => <ProjectLinks project={project}></ProjectLinks>}
+      </ProjectView>
+    </>
+  );
 };
 
 export default ProjectLinkPage;

--- a/pages/projects/[id]/links.tsx
+++ b/pages/projects/[id]/links.tsx
@@ -1,0 +1,16 @@
+import ProjectView from "../../../components/ProjectView/ProjectView";
+import ProjectLinks from "../../../components/ProjectView/ProjectLinks";
+
+const ProjectLinkPage = (): React.ReactElement => {
+    return (
+        <>
+            <ProjectView projectId={1}>
+                {(project) => (
+                    <ProjectLinks project={project}></ProjectLinks>
+                )}
+            </ProjectView>
+        </>
+    );
+};
+
+export default ProjectLinkPage;

--- a/pages/projects/[id]/links/add.tsx
+++ b/pages/projects/[id]/links/add.tsx
@@ -1,0 +1,66 @@
+import { useRouter } from "next/router";
+import { useState } from "react";
+import { useForm } from "react-hook-form";
+import Button from "../../../../components/Button/Button"
+import TextInput from "../../../../components/TextInput/TextInput";
+import { addProjectLink } from "../../../../utils/projectLinks";
+
+
+interface FormData {
+    type: string;
+    link: string;
+
+}
+
+const AddNewLinkPage = (): React.ReactElement => {
+    const {
+        register,
+        handleSubmit,
+        formState: { errors },
+    } = useForm();
+    const { push, query } = useRouter();
+    const project_id = Number(query.id)
+    const [error, setError] = useState(false);
+
+    const onFormSubmit = async ({ ...data }: FormData) => {
+        try {
+            await addProjectLink({ project_id, ...data });
+            //push(`/projects/${project_id}/projects/confirmation`);
+        } catch (e) {
+            console.log(e);
+            setError(true);
+        }
+    };
+
+    return (
+        <div className="govuk-width-container">
+
+            <form role="form" onSubmit={handleSubmit(onFormSubmit)}>
+                <h1 className="govuk-fieldset__legend--l gov-weight-lighter">
+                    New Link
+                </h1>
+                <TextInput
+                    name="type"
+                    label="Link type"
+                    required={true}
+                    register={register}
+                    rules={{ required: "A name for the link is required" }}
+                    error={errors.type}
+                    width={20}
+                />
+                <TextInput
+                    name="link"
+                    label="Link"
+                    required={true}
+                    register={register}
+                    rules={{ required: "A link is required" }}
+                    error={errors.link}
+
+                />
+                <Button label="Finish" type="submit" />
+            </form>
+        </div>
+    );
+};
+
+export default AddNewLinkPage;

--- a/pages/projects/[id]/links/add.tsx
+++ b/pages/projects/[id]/links/add.tsx
@@ -1,66 +1,62 @@
 import { useRouter } from "next/router";
 import { useState } from "react";
 import { useForm } from "react-hook-form";
-import Button from "../../../../components/Button/Button"
+import Button from "../../../../components/Button/Button";
 import TextInput from "../../../../components/TextInput/TextInput";
 import { addProjectLink } from "../../../../utils/projectLinks";
 
-
 interface FormData {
-    type: string;
-    link: string;
-
+  type: string;
+  link: string;
 }
 
 const AddNewLinkPage = (): React.ReactElement => {
-    const {
-        register,
-        handleSubmit,
-        formState: { errors },
-    } = useForm();
-    const { push, query } = useRouter();
-    const project_id = Number(query.id)
-    const [error, setError] = useState(false);
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm();
+  const { push, query } = useRouter();
+  const project_id = Number(query.id);
+  const [error, setError] = useState(false);
 
-    const onFormSubmit = async ({ ...data }: FormData) => {
-        try {
-            await addProjectLink({ project_id, ...data });
-            //push(`/projects/${project_id}/projects/confirmation`);
-        } catch (e) {
-            console.log(e);
-            setError(true);
-        }
-    };
+  const onFormSubmit = async ({ ...data }: FormData) => {
+    try {
+      await addProjectLink({ project_id, ...data });
+      //push(`/projects/${project_id}/projects/confirmation`);
+    } catch (e) {
+      console.log(e);
+      setError(true);
+    }
+  };
 
-    return (
-        <div className="govuk-width-container">
-
-            <form role="form" onSubmit={handleSubmit(onFormSubmit)}>
-                <h1 className="govuk-fieldset__legend--l gov-weight-lighter">
-                    New Link
-                </h1>
-                <TextInput
-                    name="type"
-                    label="Link type"
-                    required={true}
-                    register={register}
-                    rules={{ required: "A name for the link is required" }}
-                    error={errors.type}
-                    width={20}
-                />
-                <TextInput
-                    name="link"
-                    label="Link"
-                    required={true}
-                    register={register}
-                    rules={{ required: "A link is required" }}
-                    error={errors.link}
-
-                />
-                <Button label="Finish" type="submit" />
-            </form>
-        </div>
-    );
+  return (
+    <div className="govuk-width-container">
+      <form role="form" onSubmit={handleSubmit(onFormSubmit)}>
+        <h1 className="govuk-fieldset__legend--l gov-weight-lighter">
+          New Link
+        </h1>
+        <TextInput
+          name="type"
+          label="Link type"
+          required={true}
+          register={register}
+          rules={{ required: "A name for the link is required" }}
+          error={errors.type}
+          width={20}
+        />
+        <TextInput
+          name="link"
+          label="Link"
+          required={true}
+          register={register}
+          rules={{ required: "A link is required" }}
+          error={errors.link}
+        />
+        <Button label="Finish" type="submit" />
+      </form>
+    </div>
+  );
 };
 
 export default AddNewLinkPage;

--- a/pages/projects/[id]/team.tsx
+++ b/pages/projects/[id]/team.tsx
@@ -1,16 +1,17 @@
 import ProjectView from "../../../components/ProjectView/ProjectView";
 import ProjectTeam from "../../../components/ProjectView/ProjectTeam";
+import { useRouter } from "next/router";
 
 const ProjectTeamPage = (): React.ReactElement => {
-    return (
-        <>
-            <ProjectView projectId={1}>
-                {(project) => (
-                    <ProjectTeam project={project} />
-                )}
-            </ProjectView>
-        </>
-    );
+  const { query } = useRouter();
+  const projectId = Number(query.id);
+  return (
+    <>
+      <ProjectView projectId={projectId}>
+        {(project) => <ProjectTeam project={project} />}
+      </ProjectView>
+    </>
+  );
 };
 
 export default ProjectTeamPage;

--- a/pages/projects/[id]/team.tsx
+++ b/pages/projects/[id]/team.tsx
@@ -1,0 +1,16 @@
+import ProjectView from "../../../components/ProjectView/ProjectView";
+import ProjectTeam from "../../../components/ProjectView/ProjectTeam";
+
+const ProjectTeamPage = (): React.ReactElement => {
+    return (
+        <>
+            <ProjectView projectId={1}>
+                {(project) => (
+                    <ProjectTeam project={project} />
+                )}
+            </ProjectView>
+        </>
+    );
+};
+
+export default ProjectTeamPage;

--- a/pages/projects/[id]/team/add.tsx
+++ b/pages/projects/[id]/team/add.tsx
@@ -5,8 +5,8 @@ import Button from "../../../../components/Button/Button";
 import TextInput from "../../../../components/TextInput/TextInput";
 import Autocomplete from "../../../../components/Autocomplete/Autocomplete";
 import { addTeamMember } from "../../../../utils/projectTeam";
-
-
+//import { useUsers } from "../../../../utils/users";
+import Spinner from "../../../../components/Spinner/Spinner";
 
 interface FormData {
     member_id: number;
@@ -14,20 +14,23 @@ interface FormData {
 }
 
 const AddNewTeamMemberPage = (): React.ReactElement => {
+    const autocompleteData = [{ value: 1, text: "Test" }]
     const {
         register,
         handleSubmit,
         control,
         formState: { errors },
     } = useForm();
+    //   const { data: users, error: errorUsers } = useUsers();
+    //   const userList =
+    //     users &&
+    //     users?.map(({ id, firstName, lastName }) => ({
+    //       value: id,
+    //       text: firstName + " " + lastName,
+    //     }));
     const { push, query } = useRouter();
-    const project_id = Number(query.id)
+    const project_id = Number(query.id);
     const [error, setError] = useState(false);
-    const data = [
-        { value: 1, text: "somte" },
-        { value: 2, text: "kal el" },
-        { value: 3, text: "timmy" },
-    ];
 
     const onFormSubmit = async ({ ...data }: FormData) => {
         try {
@@ -39,10 +42,13 @@ const AddNewTeamMemberPage = (): React.ReactElement => {
         }
     };
 
+    // if (!users) {
+    //     return <Spinner />;
+    // }
+
     return (
         <div className="govuk-width-container">
-
-            <form role="form" onSubmit={handleSubmit(onFormSubmit)} >
+            <form role="form" onSubmit={handleSubmit(onFormSubmit)}>
                 <h1 className="govuk-fieldset__legend--l gov-weight-lighter">
                     New team member
                 </h1>
@@ -54,7 +60,7 @@ const AddNewTeamMemberPage = (): React.ReactElement => {
                             name={`projectMembers.name`}
                             label="Member Name"
                             control={control}
-                            choices={data}
+                            choices={autocompleteData}
                             onChange={onChange}
                             value={value}
                             width={12}
@@ -70,7 +76,6 @@ const AddNewTeamMemberPage = (): React.ReactElement => {
                     register={register}
                     rules={{ required: "A user role is required" }}
                     error={errors.role}
-
                 />
                 <Button label="Finish" type="submit" />
             </form>

--- a/pages/projects/[id]/team/add.tsx
+++ b/pages/projects/[id]/team/add.tsx
@@ -1,0 +1,81 @@
+import { useRouter } from "next/router";
+import { useState } from "react";
+import { useForm, Controller } from "react-hook-form";
+import Button from "../../../../components/Button/Button";
+import TextInput from "../../../../components/TextInput/TextInput";
+import Autocomplete from "../../../../components/Autocomplete/Autocomplete";
+import { addTeamMember } from "../../../../utils/projectTeam";
+
+
+
+interface FormData {
+    member_id: number;
+    role: string;
+}
+
+const AddNewTeamMemberPage = (): React.ReactElement => {
+    const {
+        register,
+        handleSubmit,
+        control,
+        formState: { errors },
+    } = useForm();
+    const { push, query } = useRouter();
+    const project_id = Number(query.id)
+    const [error, setError] = useState(false);
+    const data = [
+        { value: 1, text: "somte" },
+        { value: 2, text: "kal el" },
+        { value: 3, text: "timmy" },
+    ];
+
+    const onFormSubmit = async ({ ...data }: FormData) => {
+        try {
+            await addTeamMember({ project_id, ...data });
+            // push(`/projects/${project_id}/projects/confirmation`);
+        } catch (e) {
+            console.log(e);
+            setError(true);
+        }
+    };
+
+    return (
+        <div className="govuk-width-container">
+
+            <form role="form" onSubmit={handleSubmit(onFormSubmit)} >
+                <h1 className="govuk-fieldset__legend--l gov-weight-lighter">
+                    New team member
+                </h1>
+                <Controller
+                    name={`member_id`}
+                    control={control}
+                    render={({ field: { value, onChange } }) => (
+                        <Autocomplete
+                            name={`projectMembers.name`}
+                            label="Member Name"
+                            control={control}
+                            choices={data}
+                            onChange={onChange}
+                            value={value}
+                            width={12}
+                            error={errors?.member_id}
+                        />
+                    )}
+                    rules={{ required: "An employee name is required" }}
+                />
+                <TextInput
+                    name="role"
+                    label="Role"
+                    required={true}
+                    register={register}
+                    rules={{ required: "A user role is required" }}
+                    error={errors.role}
+
+                />
+                <Button label="Finish" type="submit" />
+            </form>
+        </div>
+    );
+};
+
+export default AddNewTeamMemberPage;

--- a/pages/projects/[id]/update.tsx
+++ b/pages/projects/[id]/update.tsx
@@ -1,0 +1,133 @@
+import { useRouter } from "next/router";
+import { useForm } from "react-hook-form";
+import Button from "../../../components/Button/Button";
+import Select from "../../../components/Select/Select";
+import TextArea from "../../../components/TextArea/TextArea";
+import TextInput from "../../../components/TextInput/TextInput";
+import { updateProject, useProject } from "../../../utils/projects";
+import projectPhases from "../../../data/projectPhases";
+import projectSizes from "../../../data/projectSizes";
+import projectPriority from "../../../data/ProjectPriority";
+import Spinner from "../../../components/Spinner/Spinner";
+import { useEffect } from "react";
+
+export type ProjectFormData = {
+  projectName: string;
+  description: string;
+  projectContact: string;
+  phase: string;
+  size: string;
+  priority: string;
+  productUsers: string;
+  dependencies: string;
+};
+
+const UpdateProjectPage = (): React.ReactElement => {
+  const { query, push } = useRouter();
+  const projectId = Number(query.id);
+  const { data: project } = useProject(projectId);
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm({ defaultValues: project ? project : {} });
+  const onFormSubmit = async (data: ProjectFormData) => {
+    const formData = (({
+      description,
+      phase,
+      size,
+      priority,
+      dependencies,
+    }) => ({ description, phase, size, priority, dependencies }))(data);
+    await updateProject(projectId, {
+      project_id: projectId,
+      project_name: data.projectName,
+      project_contact: data.projectContact,
+      product_users: data.productUsers,
+      ...formData,
+    });
+    push(`/projects/${projectId}/details`);
+  };
+  useEffect(() => {
+    reset({ ...project });
+  }, [project]);
+  if (!project) {
+    return <Spinner />;
+  }
+
+  return (
+    <form role="form" onSubmit={handleSubmit(onFormSubmit)}>
+      <h1 className="govuk-fieldset__legend--l gov-weight-lighter">
+        Update Project
+      </h1>
+      <TextInput
+        name="projectName"
+        label="Project Name"
+        required={true}
+        register={register}
+        rules={{ required: "A project name is required" }}
+        error={errors.projectName}
+        width={10}
+      />
+      <TextArea
+        name="description"
+        label="Project Description"
+        required={true}
+        rules={{ required: "A project description is required" }}
+        register={register}
+        error={errors.description}
+        width={30}
+      />
+      <TextInput
+        name="projectContact"
+        label="Project Contact"
+        hint="This could be a delivery or project manager"
+        register={register}
+        width={10}
+      />
+      <Select
+        name="phase"
+        label="Project Phase"
+        required={true}
+        options={projectPhases}
+        rules={{ required: "A project phase is required" }}
+        error={errors.phase}
+        register={register}
+      />
+      <Select
+        name="size"
+        label="Project Size"
+        required={true}
+        options={projectSizes}
+        rules={{ required: "A project size is required" }}
+        error={errors.size}
+        register={register}
+      />
+      <Select
+        name="priority"
+        label="Priority"
+        options={projectPriority}
+        register={register}
+      />
+      <TextArea
+        name="productUsers"
+        label="Product Users"
+        hint="Who are the users of the application?"
+        register={register}
+        width={30}
+      />
+      <TextArea
+        name="dependencies"
+        label="dependencies"
+        hint="What dependencies or related projects are there?"
+        register={register}
+        width={30}
+      />
+
+      <Button label="Finish" type="submit" />
+    </form>
+  );
+};
+
+export default UpdateProjectPage;

--- a/pages/projects/add.tsx
+++ b/pages/projects/add.tsx
@@ -5,25 +5,19 @@ import TextInput from "../../components/TextInput/TextInput";
 import TextArea from "../../components/TextArea/TextArea";
 import Select from "../../components/Select/Select";
 import { addProject } from "../../utils/projects";
-import ProjectTeamMemberInput from "../../components/FormComponents/ProjectTeamMemberInput/ProjectTeamMemberInput";
-
-const projectSizes = [
-  { text: "Small", value: "small" },
-  { text: "Medium", value: "medium" },
-  { text: "Large", value: "large" },
-];
-const projectStages = [
-  { text: "Discovery", value: "discovery" },
-  { text: "Build", value: "build" },
-  { text: "Support", value: "support" },
-];
+import projectPhases from "../../data/projectPhases";
+import projectSizes from "../../data/projectSizes";
+import projectPriority from "../../data/ProjectPriority";
 
 export type ProjectFormData = {
   projectName: string;
-  projectDescription: string;
+  description: string;
   projectContact: string;
-  projectStage: string;
-  projectSize: string;
+  phase: string;
+  size: string;
+  priority: string;
+  productUsers: string;
+  dependencies: string;
 };
 
 const NewProjectPage = (): React.ReactElement => {
@@ -53,37 +47,58 @@ const NewProjectPage = (): React.ReactElement => {
           width={10}
         />
         <TextArea
-          name="projectDescription"
+          name="description"
           label="Project Description"
           required={true}
           rules={{ required: "A project description is required" }}
           register={register}
-          error={errors.projectDescription}
+          error={errors.description}
           width={30}
         />
         <TextInput
           name="projectContact"
           label="Project Contact"
-          required={true}
-          rules={{ required: "A project contact is required" }}
           hint="This could be a delivery or project manager"
           register={register}
-          error={errors.projectContact}
           width={10}
         />
         <Select
-          name="projectStage"
-          label="Project Stage"
+          name="phase"
+          label="Project Phase"
           required={true}
-          options={projectStages}
+          options={projectPhases}
+          rules={{ required: "A project phase is required" }}
+          error={errors.phase}
           register={register}
         />
         <Select
-          name="projectSize"
+          name="size"
           label="Project Size"
           required={true}
           options={projectSizes}
+          rules={{ required: "A project size is required" }}
+          error={errors.size}
           register={register}
+        />
+        <Select
+          name="priority"
+          label="Priority"
+          options={projectPriority}
+          register={register}
+        />
+        <TextArea
+          name="productUsers"
+          label="Product Users"
+          hint="Who are the users of the application?"
+          register={register}
+          width={30}
+        />
+        <TextArea
+          name="dependencies"
+          label="dependencies"
+          hint="What dependencies or related projects are there?"
+          register={register}
+          width={30}
         />
 
         <Button label="Finish" type="submit"></Button>

--- a/styles/global.scss
+++ b/styles/global.scss
@@ -64,3 +64,14 @@ $govuk-page-width: 1100px;
     margin-top: 0;
   }
 }
+
+.govuk-table__row--clickable:hover {
+  background: govuk-colour("light-grey");
+  cursor: pointer;
+}
+
+.govuk-grid-row {
+  button {
+    margin-top: 0;
+  }
+}

--- a/styles/global.scss
+++ b/styles/global.scss
@@ -1,7 +1,12 @@
 $lbh-global-styles: true;
 $lbh-asset-path: "~lbh-frontend/lbh/assets";
+$govuk-page-width: 1100px;
 
 @import "node_modules/lbh-frontend/lbh/all";
+
+#__next {
+  margin-top: 0;
+}
 
 .lbh-table-header {
   display: flex;
@@ -26,5 +31,36 @@ $lbh-asset-path: "~lbh-frontend/lbh/assets";
 
   @include govuk-media-query($from: tablet) {
     padding: 35px;
+  }
+}
+
+// dialog styles
+:root {
+  --reach-dialog: 1;
+}
+[data-reach-dialog-overlay] {
+  background: hsla(0, 0%, 0%, 0.33);
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  overflow: auto;
+}
+[data-reach-dialog-content] {
+  width: 50vw;
+  margin: 10vh auto;
+  background: white;
+  padding: 2rem;
+  outline: none;
+}
+
+.lbh-header {
+  z-index: inherit;
+}
+
+.lbh-dialog {
+  &__close {
+    margin-top: 0;
   }
 }

--- a/types.ts
+++ b/types.ts
@@ -1,13 +1,16 @@
 import { RegisterOptions } from "react-hook-form";
 
 export interface Project {
-  project_id: number;
-  project_name: string;
+  id: number;
+  projectName: string;
   description: string;
-  stage: string;
+  projectContact: string;
+  phase: string;
   size: string;
-  type: string;
-  project_dependencies?: string;
+  category: string;
+  priority: string;
+  productUsers: string;
+  dependencies?: string;
 }
 
 export interface GenericField {
@@ -40,7 +43,7 @@ export interface ProjectLink {
 }
 
 export interface ProjectMember {
-  id: number
+  id: number;
   member_id: number;
   project_id: number;
   project_member: string;

--- a/types.ts
+++ b/types.ts
@@ -8,14 +8,6 @@ export interface Project {
   size: string;
   type: string;
   project_dependencies?: string;
-  project_links?: {
-    name: string;
-    link: string;
-  }[];
-  project_team?: {
-    name: string;
-    role: string;
-  }[];
 }
 
 export interface GenericField {
@@ -38,4 +30,19 @@ export interface User {
   hasAdminPermissions: boolean;
   hasUserPermissions: boolean;
   isAuthorised: boolean;
+}
+
+export interface ProjectLink {
+  id: number;
+  project_id: number;
+  type: string;
+  link: string;
+}
+
+export interface ProjectMember {
+  id: number
+  member_id: number;
+  project_id: number;
+  project_member: string;
+  role: string;
 }

--- a/utils/projectLinks.ts
+++ b/utils/projectLinks.ts
@@ -1,0 +1,29 @@
+import axios, { AxiosError } from "axios";
+import useSWR, { SWRResponse } from "swr";
+import { ProjectLink } from "../types";
+
+export const useProjectLinks = (
+    projectId: number
+): SWRResponse<ProjectLink[], AxiosError> => useSWR(`/api/projects/${projectId}/links`);
+
+interface addNewProjectLinkData {
+    project_id: number;
+    type: string;
+    link: string;
+}
+
+export const addProjectLink = async (
+    formData: addNewProjectLinkData
+): Promise<Record<string, string | number>> => {
+    const { data } = await axios.post(`/api/projects/${formData.project_id}/links`, formData);
+    return data;
+};
+
+export const removeProjectLink = async (
+    project_id: number,
+    link_id: number
+): Promise<Record<string, string | number>> => {
+    const { data } = await axios.delete(`/api/projects/${project_id}/links/remove/${link_id}`);
+
+    return data;
+};

--- a/utils/projectLinks.ts
+++ b/utils/projectLinks.ts
@@ -3,27 +3,33 @@ import useSWR, { SWRResponse } from "swr";
 import { ProjectLink } from "../types";
 
 export const useProjectLinks = (
-    projectId: number
-): SWRResponse<ProjectLink[], AxiosError> => useSWR(`/api/projects/${projectId}/links`);
+  projectId: number
+): SWRResponse<ProjectLink[], AxiosError> =>
+  useSWR(`/api/projects/${projectId}/links`);
 
 interface addNewProjectLinkData {
-    project_id: number;
-    type: string;
-    link: string;
+  project_id: number;
+  type: string;
+  link: string;
 }
 
 export const addProjectLink = async (
-    formData: addNewProjectLinkData
+  formData: addNewProjectLinkData
 ): Promise<Record<string, string | number>> => {
-    const { data } = await axios.post(`/api/projects/${formData.project_id}/links`, formData);
-    return data;
+  const { data } = await axios.post(
+    `/api/projects/${formData.project_id}/links`,
+    formData
+  );
+  return data;
 };
 
 export const removeProjectLink = async (
-    project_id: number,
-    link_id: number
+  project_id: number,
+  link_id: number
 ): Promise<Record<string, string | number>> => {
-    const { data } = await axios.delete(`/api/projects/${project_id}/links/remove/${link_id}`);
+  const { data } = await axios.delete(
+    `/api/projects/${project_id}/links/remove/${link_id}`
+  );
 
-    return data;
+  return data;
 };

--- a/utils/projectTeam.ts
+++ b/utils/projectTeam.ts
@@ -2,29 +2,34 @@ import axios, { AxiosError } from "axios";
 import useSWR, { SWRResponse } from "swr";
 import { ProjectMember } from "../types";
 
-
 export const useTeamMembers = (
-    projectId: number
-): SWRResponse<ProjectMember[], AxiosError> => useSWR(`/api/projects/${projectId}/team`);
+  projectId: number
+): SWRResponse<ProjectMember[], AxiosError> =>
+  useSWR(`/api/projects/${projectId}/team`);
 
 interface addNewTeamMemberData {
-    project_id: number;
-    member_id: number;
-    role: string;
+  project_id: number;
+  member_id: number;
+  role: string;
 }
 
 export const addTeamMember = async (
-    formData: addNewTeamMemberData
+  formData: addNewTeamMemberData
 ): Promise<Record<string, string | number>> => {
-    const { data } = await axios.post(`/api/projects/${formData.project_id}/team`, formData);
-    return data;
+  const { data } = await axios.post(
+    `/api/projects/${formData.project_id}/team`,
+    formData
+  );
+  return data;
 };
 
 export const removeTeamMember = async (
-    project_id: number,
-    team_member_id: number
+  project_id: number,
+  team_member_id: number
 ): Promise<Record<string, string | number>> => {
-    const { data } = await axios.delete(`/api/projects/${project_id}/team/remove/${team_member_id}`);
+  const { data } = await axios.delete(
+    `/api/projects/${project_id}/team/remove/${team_member_id}`
+  );
 
-    return data;
+  return data;
 };

--- a/utils/projectTeam.ts
+++ b/utils/projectTeam.ts
@@ -1,0 +1,30 @@
+import axios, { AxiosError } from "axios";
+import useSWR, { SWRResponse } from "swr";
+import { ProjectMember } from "../types";
+
+
+export const useTeamMembers = (
+    projectId: number
+): SWRResponse<ProjectMember[], AxiosError> => useSWR(`/api/projects/${projectId}/team`);
+
+interface addNewTeamMemberData {
+    project_id: number;
+    member_id: number;
+    role: string;
+}
+
+export const addTeamMember = async (
+    formData: addNewTeamMemberData
+): Promise<Record<string, string | number>> => {
+    const { data } = await axios.post(`/api/projects/${formData.project_id}/team`, formData);
+    return data;
+};
+
+export const removeTeamMember = async (
+    project_id: number,
+    team_member_id: number
+): Promise<Record<string, string | number>> => {
+    const { data } = await axios.delete(`/api/projects/${project_id}/team/remove/${team_member_id}`);
+
+    return data;
+};

--- a/utils/projects.ts
+++ b/utils/projects.ts
@@ -12,3 +12,11 @@ export const addProject = async (
   const { data } = await axios.post(`/api/projects`, formData);
   return data;
 };
+
+export const updateProject = async (
+  projectId: number,
+  formData: Record<string, string | number>
+): Promise<Record<string, string>> => {
+  const { data } = await axios.patch(`/api/projects/${projectId}`, formData);
+  return data;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -760,6 +760,18 @@
     react-remove-scroll "^2.4.2"
     tslib "^2.3.0"
 
+"@reach/dialog@^0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@reach/dialog/-/dialog-0.16.0.tgz#66651868bb6b149fac923f40952355252da05d53"
+  integrity sha512-EsQ6wPafXHkny7ATihGCCJuVb6bo8MzzFvsDY+BNLeUt4XN3Kcq1oe5xJbXfxbm1Ljzs80bqF3E/Q16O12fPng==
+  dependencies:
+    "@reach/portal" "0.16.0"
+    "@reach/utils" "0.16.0"
+    prop-types "^15.7.2"
+    react-focus-lock "^2.5.2"
+    react-remove-scroll "^2.4.3"
+    tslib "^2.3.0"
+
 "@reach/portal@0.15.3":
   version "0.15.3"
   resolved "https://registry.yarnpkg.com/@reach/portal/-/portal-0.15.3.tgz#56fe4f6575ff07fc7d1a151481713171c7e37c88"
@@ -768,10 +780,26 @@
     "@reach/utils" "0.15.3"
     tslib "^2.3.0"
 
+"@reach/portal@0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@reach/portal/-/portal-0.16.0.tgz#1544531d978b770770b718b2872b35652a11e7e3"
+  integrity sha512-vXJ0O9T+72HiSEWHPs2cx7YbSO7pQsTMhgqPc5aaddIYpo2clJx1PnYuS0lSNlVaDO0IxQhwYq43evXaXnmviw==
+  dependencies:
+    "@reach/utils" "0.16.0"
+    tslib "^2.3.0"
+
 "@reach/utils@0.15.3":
   version "0.15.3"
   resolved "https://registry.yarnpkg.com/@reach/utils/-/utils-0.15.3.tgz#200f42adba9d1463b1c6a75ee2aaf9f0cba84f9d"
   integrity sha512-HFyjw8LZ4/RRk5bcMpDAeEc3aOeLR/vWRDsljlE3cHI5GfFlZcG3DDLSW8C2ba74RCFp/4X3Nz0nOrd4JdkZ1w==
+  dependencies:
+    tiny-warning "^1.0.3"
+    tslib "^2.3.0"
+
+"@reach/utils@0.16.0":
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/@reach/utils/-/utils-0.16.0.tgz#5b0777cf16a7cab1ddd4728d5d02762df0ba84ce"
+  integrity sha512-PCggBet3qaQmwFNcmQ/GqHSefadAFyNCUekq9RrWoaU9hh/S4iaFgf2MBMdM47eQj5i/Bk0Mm07cP/XPFlkN+Q==
   dependencies:
     tiny-warning "^1.0.3"
     tslib "^2.3.0"
@@ -4705,7 +4733,7 @@ react-dom@17.0.2:
     object-assign "^4.1.1"
     scheduler "^0.20.2"
 
-react-focus-lock@^2.5.1:
+react-focus-lock@^2.5.1, react-focus-lock@^2.5.2:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/react-focus-lock/-/react-focus-lock-2.5.2.tgz#f1e4db5e25cd8789351f2bd5ebe91e9dcb9c2922"
   integrity sha512-WzpdOnEqjf+/A3EH9opMZWauag7gV0BxFl+EY4ElA4qFqYsUsBLnmo2sELbN5OC30S16GAWMy16B9DLPpdJKAQ==
@@ -4745,7 +4773,7 @@ react-remove-scroll-bar@^2.1.0:
     react-style-singleton "^2.1.0"
     tslib "^1.0.0"
 
-react-remove-scroll@^2.4.2:
+react-remove-scroll@^2.4.2, react-remove-scroll@^2.4.3:
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/react-remove-scroll/-/react-remove-scroll-2.4.3.tgz#83d19b02503b04bd8141ed6e0b9e6691a2e935a6"
   integrity sha512-lGWYXfV6jykJwbFpsuPdexKKzp96f3RbvGapDSIdcyGvHb7/eqyn46C7/6h+rUzYar1j5mdU+XECITHXCKBk9Q==


### PR DESCRIPTION
### What
This large PR adds quite a few changes. The biggest change is the redesign of the individual project page. This page is now split into three mini pages: one for its main details, one for its related links and one for the team members of the project.

New components have also been added to make each page more responsive such as a modal which uses the reach dialog package and a spinner component to provide visual feedback to the user while it fetches data from the back-end. This new project view has also had some of its functionality now wired up to work with the back-end such as the update project functionality. The form themselves have also been updated to better reflect the data required for the API.

The `Project` type has been updated to reflect the data returned from the back-end.

The `ProjectsTable` component which displays all the projects after a search has been updated to display one less category which is the `type` category and each result links to its respective project. 
### Why
This project page was redesigned to better present information to users. By separating each piece of information of a project into separate pages a user is not bombarded with a vast amount of information on one page. Furthermore it makes the page look more presentable if certain information isn't present such as if no team has been added as now they return a default message if such data is missing.

Finally it makes the project view more extendable as if new information needs to be added a new page can be created for it rather than further extending the previous single page.

### Anything else?
Certain aspects still need to be wired up to the back-end such as the creation of a project. Further testing would be a nice to have and redirects are needed if a certain user does not have the correct permissions to access certain features such as updating a project. Finally the update `ProjectsTable` should be displayed once the project search component has been created.