### PR TITLE
Update: User functionality wire up

### DIFF
--- a/api/users.ts
+++ b/api/users.ts
@@ -3,24 +3,29 @@ import axios from "axios";
 import { SystemUser } from "../types";
 
 const ENDPOINT_API = process.env.ENDPOINT_API;
+const API_KEY = process.env.API_KEY;
+
+const keyHeader = {
+  'x-api-key': API_KEY
+}
 
 export const getUsers = async (): Promise<SystemUser[] | []> => {
-  const { data } = await axios.get(`${ENDPOINT_API}/users`);
+  const { data } = await axios.get(`${ENDPOINT_API}/users`, { headers: keyHeader });
 
   return data;
 };
 
 export const getUserByEmail = async (email: string): Promise<SystemUser> => {
   const { data } = await axios.get(`${ENDPOINT_API}/users/email`, {
+    headers: keyHeader,
     params: { email_address: email },
   });
   return data;
 };
 
 export const addUser = async (formData: SystemUser): Promise<SystemUser> => {
-  console.log(ENDPOINT_API);
   const { data } = await axios.post(`${ENDPOINT_API}/users`, formData, {
-    headers: { "Content-Type": "application/json" },
+    headers: keyHeader,
   });
   return data;
 };

--- a/utils/users.ts
+++ b/utils/users.ts
@@ -8,7 +8,7 @@ export const useUsers = (): SWRResponse<SystemUser[], AxiosError> =>
 export const useUserByEmail = (
   email: string | undefined
 ): SWRResponse<SystemUser, AxiosError> =>
-  useSWR(`/api/users?email=${email}`);
+  useSWR(email ? `/api/users?email=${email}` : null);
 
 export const addUser = async (
   formData: Record<string, string>


### PR DESCRIPTION
### What
This PR introduces two small changes. The first change is sending the `x-api-key` header to the back-end when a request is made and the second is a small conditional statement has been added to the `useUserByEmail` utils function.
### Why
The addition of the header allows the API gateway for the API to authorise the request, allowing it to be successful is the correct key is given. The conditional statement is to stop the user search page from constantly returning a 404 when no email is inputted into the search. 
### Anything else?
Nothing else to add